### PR TITLE
Update chk query util

### DIFF
--- a/src/richchk/io/richchk/decoded_str_section_rebuilder.py
+++ b/src/richchk/io/richchk/decoded_str_section_rebuilder.py
@@ -3,9 +3,7 @@
 import dataclasses
 
 from ...editor.chk.decoded_str_section_editor import DecodedStrSectionEditor
-from ...model.chk.decoded_chk_section import DecodedChkSection
 from ...model.chk.str.decoded_str_section import DecodedStrSection
-from ...model.chk_section_name import ChkSectionName
 from ...model.richchk.rich_chk import RichChk
 from ...model.richchk.rich_chk_section import RichChkSection
 from ...model.richchk.str.rich_string import RichNullString, RichString
@@ -15,9 +13,8 @@ from ..util.chk_query_util import ChkQueryUtil
 class DecodedStrSectionRebuilder:
     @staticmethod
     def rebuild_str_section_from_rich_chk(rich_chk: RichChk) -> DecodedStrSection:
-        decoded_str: DecodedStrSection = DecodedChkSection.cast(
-            ChkQueryUtil.find_only_decoded_section_in_chk(ChkSectionName.STR, rich_chk),
-            DecodedStrSection,
+        decoded_str = ChkQueryUtil.find_only_decoded_section_in_chk(
+            DecodedStrSection, rich_chk
         )
         rich_strings: set[
             RichString

--- a/src/richchk/io/richchk/lookups/mrgn/rich_mrgn_section_rebuilder.py
+++ b/src/richchk/io/richchk/lookups/mrgn/rich_mrgn_section_rebuilder.py
@@ -11,7 +11,6 @@ allocated to "Anywhere".
 import dataclasses
 
 from .....editor.richchk.rich_mrgn_editor import RichMrgnEditor
-from .....model.chk_section_name import ChkSectionName
 from .....model.richchk.mrgn.rich_location import RichLocation
 from .....model.richchk.mrgn.rich_mrgn_section import RichMrgnSection
 from .....model.richchk.rich_chk import RichChk
@@ -22,9 +21,8 @@ from ....util.chk_query_util import ChkQueryUtil
 class RichMrgnSectionRebuilder:
     @staticmethod
     def rebuild_rich_mrgn_section_from_rich_chk(rich_chk: RichChk) -> RichMrgnSection:
-        rich_mrgn: RichMrgnSection = RichChkSection.cast(
-            ChkQueryUtil.find_only_rich_section_in_chk(ChkSectionName.MRGN, rich_chk),
-            RichMrgnSection,
+        rich_mrgn = ChkQueryUtil.find_only_rich_section_in_chk(
+            RichMrgnSection, rich_chk
         )
         all_rich_locations: set[
             RichLocation

--- a/src/richchk/io/richchk/lookups/swnm/rich_swnm_rebuilder.py
+++ b/src/richchk/io/richchk/lookups/swnm/rich_swnm_rebuilder.py
@@ -8,7 +8,6 @@ import dataclasses
 from typing import Tuple
 
 from .....model.chk.swnm.swnm_constants import MAX_SWITCHES
-from .....model.chk_section_name import ChkSectionName
 from .....model.richchk.rich_chk import RichChk
 from .....model.richchk.rich_chk_section import RichChkSection
 from .....model.richchk.str.rich_string import RichNullString
@@ -124,12 +123,7 @@ class RichSwnmRebuilder:
     @classmethod
     def _find_or_create_rich_swnm(cls, rich_chk: RichChk) -> RichSwnmSection:
         try:
-            swnm: RichSwnmSection = RichChkSection.cast(
-                ChkQueryUtil.find_only_rich_section_in_chk(
-                    ChkSectionName.SWNM, rich_chk
-                ),
-                RichSwnmSection,
-            )
+            swnm = ChkQueryUtil.find_only_rich_section_in_chk(RichSwnmSection, rich_chk)
             return swnm
         except ValueError:
             cls._LOG.info("No RichSwnm found; creating a new SWNM section")

--- a/src/richchk/io/richchk/richchk_io.py
+++ b/src/richchk/io/richchk/richchk_io.py
@@ -7,7 +7,6 @@ from ...model.chk.mrgn.decoded_mrgn_section import DecodedMrgnSection
 from ...model.chk.str.decoded_str_section import DecodedStrSection
 from ...model.chk.swnm.decoded_swnm_section import DecodedSwnmSection
 from ...model.chk.unknown.decoded_unknown_section import DecodedUnknownSection
-from ...model.chk_section_name import ChkSectionName
 from ...model.richchk.mrgn.rich_mrgn_lookup import RichMrgnLookup
 from ...model.richchk.mrgn.rich_mrgn_section import RichMrgnSection
 from ...model.richchk.rich_chk import RichChk
@@ -127,15 +126,11 @@ class RichChkIo:
 
     def _build_decode_context(self, chk: DecodedChk) -> RichChkDecodeContext:
         rich_str_lookup = RichStrLookupBuilder().build_lookup(
-            DecodedChkSection.cast(
-                ChkQueryUtil.find_only_decoded_section_in_chk(ChkSectionName.STR, chk),
-                DecodedStrSection,
-            )
+            ChkQueryUtil.find_only_decoded_section_in_chk(DecodedStrSection, chk)
         )
         rich_mrgn = RichChkMrgnTranscoder().decode(
-            decoded_chk_section=DecodedChkSection.cast(
-                ChkQueryUtil.find_only_decoded_section_in_chk(ChkSectionName.MRGN, chk),
-                DecodedMrgnSection,
+            decoded_chk_section=ChkQueryUtil.find_only_decoded_section_in_chk(
+                DecodedMrgnSection, chk
             ),
             rich_chk_decode_context=RichChkDecodeContext(
                 _rich_str_lookup=rich_str_lookup,
@@ -156,9 +151,8 @@ class RichChkIo:
         self, chk: DecodedChk, rich_str_lookup: RichStrLookup
     ) -> RichSwnmLookup:
         try:
-            swnm = DecodedChkSection.cast(
-                ChkQueryUtil.find_only_decoded_section_in_chk(ChkSectionName.SWNM, chk),
-                DecodedSwnmSection,
+            swnm = ChkQueryUtil.find_only_decoded_section_in_chk(
+                DecodedSwnmSection, chk
             )
             return RichSwnmLookupBuilder().build_lookup(
                 decoded_swnm=swnm, rich_str_lookup=rich_str_lookup

--- a/src/richchk/io/util/chk_query_util.py
+++ b/src/richchk/io/util/chk_query_util.py
@@ -8,40 +8,43 @@ from ...model.chk_section_name import ChkSectionName
 from ...model.richchk.rich_chk import RichChk
 from ...model.richchk.rich_chk_section import RichChkSection
 
-_T = TypeVar("_T", bound="RichChkSection", covariant=True)
+_T = TypeVar("_T", bound=RichChkSection, covariant=True)
+_U = TypeVar("_U", bound=DecodedChkSection, covariant=True)
 
 
 class ChkQueryUtil:
     @staticmethod
     def find_only_decoded_section_in_chk(
-        chk_section_name: ChkSectionName, chk: Union[DecodedChk, RichChk]
-    ) -> DecodedChkSection:
+        chk_section_type: Type[_U], chk: Union[DecodedChk, RichChk]
+    ) -> _U:
         """Find the only DecodedChkSection with the given name.
 
         Throws if the section does not exist or there is more than 1 section with the
         same name.
 
-        :param chk_section_name:
+        :param chk_section_type:
         :param chk:
         :return:
         """
         named_sections: list[Union[DecodedChkSection, RichChkSection]] = []
         if isinstance(chk, RichChk):
-            named_sections = chk.get_sections_by_name(chk_section_name=chk_section_name)
+            named_sections = chk.get_sections_by_name(
+                chk_section_name=chk_section_type.section_name()
+            )
         elif isinstance(chk, DecodedChk):
             decoded_chk_sections = chk.get_sections_by_name(
-                chk_section_name=chk_section_name
+                chk_section_name=chk_section_type.section_name()
             )
             named_sections += decoded_chk_sections
         if not named_sections:
             msg = (
-                f"The CHK has no {chk_section_name.value} sections present! "
+                f"The CHK has no {chk_section_type.section_name().value} sections present! "
                 "The CHK may not be valid.  Only pass in valid CHK data."
             )
             raise ValueError(msg)
         if len(named_sections) > 1:
             msg = (
-                f"The CHK has more than 1 {chk_section_name.value} sections present"
+                f"The CHK has more than 1 {chk_section_type.section_name().value} sections present"
                 f" when only 1 is expected!"
             )
             raise ValueError(msg)
@@ -49,8 +52,9 @@ class ChkQueryUtil:
         if isinstance(only_section, RichChkSection):
             raise ValueError(
                 f"Expected a DecodedChkSection but found a RichChkSection "
-                f"for section named {chk_section_name.value}"
+                f"for section named {chk_section_type.section_name().value}"
             )
+        assert isinstance(only_section, chk_section_type)
         return only_section
 
     @staticmethod

--- a/src/richchk/io/util/chk_query_util.py
+++ b/src/richchk/io/util/chk_query_util.py
@@ -1,12 +1,14 @@
 """Query DecodedChk and RichChk sections."""
 
-from typing import Union
+from typing import Type, TypeVar, Union
 
 from ...model.chk.decoded_chk import DecodedChk
 from ...model.chk.decoded_chk_section import DecodedChkSection
 from ...model.chk_section_name import ChkSectionName
 from ...model.richchk.rich_chk import RichChk
 from ...model.richchk.rich_chk_section import RichChkSection
+
+_T = TypeVar("_T", bound="RichChkSection", covariant=True)
 
 
 class ChkQueryUtil:
@@ -53,29 +55,29 @@ class ChkQueryUtil:
 
     @staticmethod
     def find_only_rich_section_in_chk(
-        chk_section_name: ChkSectionName, rich_chk: RichChk
-    ) -> RichChkSection:
+        chk_section_type: Type[_T], rich_chk: RichChk
+    ) -> _T:
         """Find the only RichChkSection with the given name.
 
         Throws if the section does not exist or there is more than 1 section with the
         same name.
 
-        :param chk_section_name:
+        :param chk_section_type:
         :param rich_chk:
         :return:
         """
         named_sections = rich_chk.get_sections_by_name(
-            chk_section_name=chk_section_name
+            chk_section_name=chk_section_type.section_name()
         )
         if not named_sections:
             msg = (
-                f"The CHK has no {chk_section_name.value} sections present! "
+                f"The CHK has no {chk_section_type.section_name().value} sections present! "
                 "The CHK is not valid.  Only pass in valid CHK data."
             )
             raise ValueError(msg)
         if len(named_sections) > 1:
             msg = (
-                f"The CHK has more than 1 {chk_section_name.value} sections present"
+                f"The CHK has more than 1 {chk_section_type.section_name().value} sections present"
                 f" when only 1 is expected!"
             )
             raise ValueError(msg)
@@ -83,8 +85,9 @@ class ChkQueryUtil:
         if isinstance(only_section, DecodedChkSection):
             raise ValueError(
                 f"Expected a RichChkSection but found a DecodedChkSection "
-                f"for section named {chk_section_name.value}"
+                f"for section named {chk_section_type.section_name().value}"
             )
+        assert isinstance(only_section, chk_section_type)
         return only_section
 
     @staticmethod

--- a/test/e2e/e2e_edit_rich_chk_mrgn_test.py
+++ b/test/e2e/e2e_edit_rich_chk_mrgn_test.py
@@ -11,7 +11,6 @@ from richchk.io.chk.chk_io import ChkIo
 from richchk.io.richchk.richchk_io import RichChkIo
 from richchk.io.util.chk_query_util import ChkQueryUtil
 from richchk.model.chk.decoded_chk_section import DecodedChkSection
-from richchk.model.chk_section_name import ChkSectionName
 from richchk.model.richchk.mrgn.rich_location import RichLocation
 from richchk.model.richchk.mrgn.rich_mrgn_section import RichMrgnSection
 from richchk.model.richchk.rich_chk import RichChk
@@ -41,7 +40,7 @@ def test_integration_it_edits_mrgn_in_rich_chk(
     rich_chk_for_scx_file, chk_output_file_path
 ):
     mrgn = ChkQueryUtil.find_only_rich_section_in_chk(
-        ChkSectionName.MRGN, rich_chk_for_scx_file
+        RichMrgnSection, rich_chk_for_scx_file
     )
     assert isinstance(mrgn, RichMrgnSection)
     new_location = RichLocation(
@@ -67,9 +66,8 @@ def test_integration_it_edits_mrgn_in_rich_chk(
     )
     _assert_rich_chk_has_expected_mrgn_section(new_mrgn, rich_chk_again)
     rich_mrgn_again = ChkQueryUtil.find_only_rich_section_in_chk(
-        ChkSectionName.MRGN, rich_chk_again
+        RichMrgnSection, rich_chk_again
     )
-    assert isinstance(rich_mrgn_again, RichMrgnSection)
     _assert_mrgn_has_expected_locations_ignoring_index(
         expected_locations, rich_mrgn_again
     )
@@ -83,9 +81,7 @@ def _assert_all_locations_have_index(locations: list[RichLocation]):
 def _assert_rich_chk_has_expected_mrgn_section(
     expected_mrgn: RichMrgnSection, rich_chk
 ):
-    actual_mrgn = ChkQueryUtil.find_only_rich_section_in_chk(
-        ChkSectionName.MRGN, rich_chk
-    )
+    actual_mrgn = ChkQueryUtil.find_only_rich_section_in_chk(RichMrgnSection, rich_chk)
     assert isinstance(actual_mrgn, RichMrgnSection)
     assert set(actual_mrgn.locations) == set(expected_mrgn.locations)
 

--- a/test/io/richchk/rich_chk_io_swnm_test.py
+++ b/test/io/richchk/rich_chk_io_swnm_test.py
@@ -136,14 +136,8 @@ def test_integration_it_adds_new_switches_when_some_switches_already_exist(
     ChkQueryUtil.determine_if_rich_chk_contains_section(
         ChkSectionName.SWNM, rich_chk_again
     )
-    swnm = RichChkSection.cast(
-        ChkQueryUtil.find_only_rich_section_in_chk(ChkSectionName.SWNM, rich_chk_again),
-        RichSwnmSection,
-    )
-    trig = RichChkSection.cast(
-        ChkQueryUtil.find_only_rich_section_in_chk(ChkSectionName.TRIG, rich_chk_again),
-        RichTrigSection,
-    )
+    swnm = ChkQueryUtil.find_only_rich_section_in_chk(RichSwnmSection, rich_chk_again)
+    trig = ChkQueryUtil.find_only_rich_section_in_chk(RichTrigSection, rich_chk_again)
     assert_triggers_all_have_allocated_switches(trig.triggers)
     assert_switch_exists_with_rich_string(
         swnm.switches, new_switch_with_name.custom_name

--- a/test/io/richchk/rich_chk_io_swnm_test.py
+++ b/test/io/richchk/rich_chk_io_swnm_test.py
@@ -6,7 +6,6 @@ from richchk.model.chk.str.decoded_str_section import DecodedStrSection
 from richchk.model.chk_section_name import ChkSectionName
 from richchk.model.richchk.mrgn.rich_mrgn_section import RichMrgnSection
 from richchk.model.richchk.rich_chk import RichChk
-from richchk.model.richchk.rich_chk_section import RichChkSection
 from richchk.model.richchk.str.rich_string import RichString
 from richchk.model.richchk.swnm.rich_switch import RichSwitch
 from richchk.model.richchk.swnm.rich_swnm_section import RichSwnmSection
@@ -88,14 +87,8 @@ def test_integration_it_adds_new_switches_when_they_are_used(rich_chk_with_no_sw
     ChkQueryUtil.determine_if_rich_chk_contains_section(
         ChkSectionName.SWNM, rich_chk_again
     )
-    swnm = RichChkSection.cast(
-        ChkQueryUtil.find_only_rich_section_in_chk(ChkSectionName.SWNM, rich_chk_again),
-        RichSwnmSection,
-    )
-    trig = RichChkSection.cast(
-        ChkQueryUtil.find_only_rich_section_in_chk(ChkSectionName.TRIG, rich_chk_again),
-        RichTrigSection,
-    )
+    swnm = ChkQueryUtil.find_only_rich_section_in_chk(RichSwnmSection, rich_chk_again)
+    trig = ChkQueryUtil.find_only_rich_section_in_chk(RichTrigSection, rich_chk_again)
     assert_triggers_all_have_allocated_switches(trig.triggers)
     assert_switch_exists_with_rich_string(
         swnm.switches, new_switch_with_name.custom_name


### PR DESCRIPTION
This removes the need to explicitly cast the found decoded or rich chk section when using the `ChkQueryUtil`.  