### PR TITLE
replace tempfile with safer cross platform tempfile

### DIFF
--- a/test/io/mpq/starcraft_mpq_io_test.py
+++ b/test/io/mpq/starcraft_mpq_io_test.py
@@ -8,50 +8,32 @@ from richchk.editor.richchk.rich_trig_editor import RichTrigEditor
 from richchk.io.mpq.starcraft_mpq_io import StarCraftMpqIo
 from richchk.io.mpq.starcraft_wav_metadata_io import StarCraftWavMetadataIo
 from richchk.io.richchk.query.chk_query_util import ChkQueryUtil
-from richchk.model.mpq.stormlib.stormlib_file_path import StormLibFilePath
 from richchk.model.richchk.rich_chk import RichChk
 from richchk.model.richchk.trig.actions.play_wav_action import PlayWavAction
 from richchk.model.richchk.trig.conditions.always_condition import AlwaysCondition
 from richchk.model.richchk.trig.player_id import PlayerId
 from richchk.model.richchk.trig.rich_trig_section import RichTrigSection
 from richchk.model.richchk.trig.rich_trigger import RichTrigger
-from richchk.mpq.stormlib.stormlib_loader import StormLibLoader
-from richchk.mpq.stormlib.stormlib_wrapper import StormLibWrapper
 from richchk.util.fileutils import CrossPlatformSafeTemporaryNamedFile
 
-from ...chk_resources import (
-    EXAMPLE_STARCRAFT_SCM_MAP,
-    EXAMPLE_STARCRAFT_SCX_MAP,
-    MACOS_STORMLIB_M1,
-)
-from ...helpers.stormlib_test_helper import run_test_if_mac_m1
+from ...chk_resources import EXAMPLE_STARCRAFT_SCM_MAP, EXAMPLE_STARCRAFT_SCX_MAP
 
 # the canonical place the CHK is stored in a SCX/SCM map file
 _CHK_MPQ_PATH = "staredit\\scenario.chk"
 
 
+@pytest.mark.usefixtures("embedded_stormlib")
 @pytest.fixture(scope="function")
-def stormlib_wrapper():
-    if run_test_if_mac_m1():
-        return StormLibWrapper(
-            StormLibLoader.load_stormlib(
-                path_to_stormlib=StormLibFilePath(
-                    _path_to_stormlib_dll=MACOS_STORMLIB_M1
-                )
-            )
-        )
+def mpq_io(embedded_stormlib):
+    if embedded_stormlib:
+        return StarCraftMpqIo(embedded_stormlib)
 
 
+@pytest.mark.usefixtures("embedded_stormlib")
 @pytest.fixture(scope="function")
-def mpq_io(stormlib_wrapper):
-    if stormlib_wrapper:
-        return StarCraftMpqIo(stormlib_wrapper)
-
-
-@pytest.fixture(scope="function")
-def wav_metadata_io(stormlib_wrapper):
-    if stormlib_wrapper:
-        return StarCraftWavMetadataIo(stormlib_wrapper)
+def wav_metadata_io(embedded_stormlib):
+    if embedded_stormlib:
+        return StarCraftWavMetadataIo(embedded_stormlib)
 
 
 def _read_file_as_bytes(infile: str) -> bytes:

--- a/test/io/mpq/starcraft_wav_metadata_io_test.py
+++ b/test/io/mpq/starcraft_wav_metadata_io_test.py
@@ -1,5 +1,4 @@
 import shutil
-import tempfile
 import uuid
 
 import pytest
@@ -9,6 +8,7 @@ from richchk.model.mpq.stormlib.stormlib_file_path import StormLibFilePath
 from richchk.model.mpq.stormlib.wav.stormlib_wav import StormLibWav
 from richchk.mpq.stormlib.stormlib_loader import StormLibLoader
 from richchk.mpq.stormlib.stormlib_wrapper import StormLibWrapper
+from richchk.util.fileutils import CrossPlatformSafeTemporaryNamedFile
 
 from ...chk_resources import (
     COMPLEX_STARCRAFT_SCX_MAP,
@@ -52,11 +52,9 @@ def _read_file_as_bytes(infile: str) -> bytes:
 
 def test_it_extracts_all_wav_metadata(wav_metadata_io):
     if wav_metadata_io:
-        with tempfile.NamedTemporaryFile() as temp_scx_file:
-            shutil.copy(COMPLEX_STARCRAFT_SCX_MAP, temp_scx_file.name)
-            wav_metadata = wav_metadata_io.extract_all_wav_files_metadata(
-                temp_scx_file.name
-            )
+        with CrossPlatformSafeTemporaryNamedFile() as temp_scx_file:
+            shutil.copy(COMPLEX_STARCRAFT_SCX_MAP, temp_scx_file)
+            wav_metadata = wav_metadata_io.extract_all_wav_files_metadata(temp_scx_file)
             expected_metadata = {
                 StormLibWav(_path_to_wav_in_mpq=key, _duration_ms=value)
                 for (key, value) in _EXPECTED_WAV_FILE_DURATIONS_MS.items()
@@ -66,23 +64,19 @@ def test_it_extracts_all_wav_metadata(wav_metadata_io):
 
 def test_it_returns_empty_list_if_no_wav_files_present(wav_metadata_io):
     if wav_metadata_io:
-        with tempfile.NamedTemporaryFile() as temp_scx_file:
-            shutil.copy(EXAMPLE_STARCRAFT_SCM_MAP, temp_scx_file.name)
-            wav_metadata = wav_metadata_io.extract_all_wav_files_metadata(
-                temp_scx_file.name
-            )
+        with CrossPlatformSafeTemporaryNamedFile() as temp_scx_file:
+            shutil.copy(EXAMPLE_STARCRAFT_SCM_MAP, temp_scx_file)
+            wav_metadata = wav_metadata_io.extract_all_wav_files_metadata(temp_scx_file)
             assert wav_metadata == []
 
 
 def test_it_extracts_same_metadata_multiple_times(wav_metadata_io):
     if wav_metadata_io:
-        with tempfile.NamedTemporaryFile() as temp_scx_file:
-            shutil.copy(COMPLEX_STARCRAFT_SCX_MAP, temp_scx_file.name)
-            wav_metadata = wav_metadata_io.extract_all_wav_files_metadata(
-                temp_scx_file.name
-            )
+        with CrossPlatformSafeTemporaryNamedFile() as temp_scx_file:
+            shutil.copy(COMPLEX_STARCRAFT_SCX_MAP, temp_scx_file)
+            wav_metadata = wav_metadata_io.extract_all_wav_files_metadata(temp_scx_file)
             wav_metadata_again = wav_metadata_io.extract_all_wav_files_metadata(
-                temp_scx_file.name
+                temp_scx_file
             )
             assert set(wav_metadata) == set(wav_metadata_again)
 

--- a/test/mpq/stormlib/search/stormlib_file_searcher_test.py
+++ b/test/mpq/stormlib/search/stormlib_file_searcher_test.py
@@ -1,5 +1,4 @@
 import shutil
-import tempfile
 
 import pytest
 
@@ -8,6 +7,7 @@ from richchk.model.mpq.stormlib.stormlib_file_path import StormLibFilePath
 from richchk.mpq.stormlib.stormlib_file_searcher import StormLibFileSearcher
 from richchk.mpq.stormlib.stormlib_loader import StormLibLoader
 from richchk.mpq.stormlib.stormlib_wrapper import StormLibWrapper
+from richchk.util.fileutils import CrossPlatformSafeTemporaryNamedFile
 
 from ....chk_resources import (
     COMPLEX_STARCRAFT_SCX_MAP,
@@ -60,10 +60,10 @@ def _read_file_as_bytes(infile: str) -> bytes:
 
 def test_it_finds_all_files_in_scx_map(stormlib_wrapper):
     if stormlib_wrapper:
-        with tempfile.NamedTemporaryFile() as temp_scx_file:
-            shutil.copyfile(COMPLEX_STARCRAFT_SCX_MAP, temp_scx_file.name)
+        with CrossPlatformSafeTemporaryNamedFile() as temp_scx_file:
+            shutil.copyfile(COMPLEX_STARCRAFT_SCX_MAP, temp_scx_file)
             open_result = stormlib_wrapper.open_archive(
-                temp_scx_file.name,
+                temp_scx_file,
                 archive_mode=StormLibArchiveMode.STORMLIB_READ_ONLY,
             )
             searcher = StormLibFileSearcher(
@@ -77,10 +77,10 @@ def test_it_finds_all_files_in_scx_map(stormlib_wrapper):
 
 def test_it_finds_all_wav_files_in_scx_map(stormlib_wrapper):
     if stormlib_wrapper:
-        with tempfile.NamedTemporaryFile() as temp_scx_file:
-            shutil.copyfile(COMPLEX_STARCRAFT_SCX_MAP, temp_scx_file.name)
+        with CrossPlatformSafeTemporaryNamedFile() as temp_scx_file:
+            shutil.copyfile(COMPLEX_STARCRAFT_SCX_MAP, temp_scx_file)
             open_result = stormlib_wrapper.open_archive(
-                temp_scx_file.name,
+                temp_scx_file,
                 archive_mode=StormLibArchiveMode.STORMLIB_READ_ONLY,
             )
             searcher = StormLibFileSearcher(
@@ -94,10 +94,10 @@ def test_it_finds_all_wav_files_in_scx_map(stormlib_wrapper):
 
 def test_it_returns_empty_list_if_no_files_found(stormlib_wrapper):
     if stormlib_wrapper:
-        with tempfile.NamedTemporaryFile() as temp_scx_file:
-            shutil.copyfile(COMPLEX_STARCRAFT_SCX_MAP, temp_scx_file.name)
+        with CrossPlatformSafeTemporaryNamedFile() as temp_scx_file:
+            shutil.copyfile(COMPLEX_STARCRAFT_SCX_MAP, temp_scx_file)
             open_result = stormlib_wrapper.open_archive(
-                temp_scx_file.name,
+                temp_scx_file,
                 archive_mode=StormLibArchiveMode.STORMLIB_READ_ONLY,
             )
             searcher = StormLibFileSearcher(

--- a/test/util/logger_test.py
+++ b/test/util/logger_test.py
@@ -1,11 +1,11 @@
 import logging
 import os
-import tempfile
 
 import yaml
 
 from richchk.config.richchk_config import RICHCHK_CONFIG_ENV_VAR
 from richchk.util import logger
+from richchk.util.fileutils import CrossPlatformSafeTemporaryNamedFile
 
 
 def test_it_creates_logger_with_default_log_level_if_no_config_specified():
@@ -14,13 +14,13 @@ def test_it_creates_logger_with_default_log_level_if_no_config_specified():
 
 
 def test_it_creates_logger_with_config_log_level():
-    with tempfile.NamedTemporaryFile(
+    with CrossPlatformSafeTemporaryNamedFile(
         prefix="config", suffix=".yaml"
     ) as temp_config_file:
         configdata = {"logging": {"level": "DEBUG"}}
-        with open(temp_config_file.name, "w") as f:
+        with open(temp_config_file, "w") as f:
             yaml.dump(configdata, f, default_flow_style=False)
-        os.environ[RICHCHK_CONFIG_ENV_VAR] = temp_config_file.name
+        os.environ[RICHCHK_CONFIG_ENV_VAR] = temp_config_file
         log = logger.get_logger("test_logger")
         assert log.level == logging.DEBUG
 


### PR DESCRIPTION
Only for unit tests for now.  

Tempfile isn't safe to use on Windows due to its limit of only 1 file being held open at a time.  See: https://stackoverflow.com/questions/23212435/permission-denied-to-write-to-my-temporary-file 