### PR TITLE
Optimize encode_chk performance: ~7x speedup on large trigger-heavy maps

### DIFF
--- a/src/richchk/editor/chk/decoded_str_section_editor.py
+++ b/src/richchk/editor/chk/decoded_str_section_editor.py
@@ -24,14 +24,8 @@ class DecodedStrSectionEditor:
             strings_to_add, decoded_str_section
         )
         if not unique_strings_to_add:
-            self.log.warning(
-                "No new strings to add.  Not performing any modifications."
-            )
-            return DecodedStrSection(
-                _number_of_strings=decoded_str_section.number_of_strings,
-                _string_offsets=decoded_str_section.strings_offsets,
-                _strings=decoded_str_section.strings,
-            )
+            self.log.debug("No new strings to add.  Not performing any modifications.")
+            return decoded_str_section
         return self._add_strings_to_str(unique_strings_to_add, decoded_str_section)
 
     def _make_strings_to_add_unique(
@@ -42,7 +36,7 @@ class DecodedStrSectionEditor:
         already_existing_strings = set(decoded_str_section.strings)
         for string_to_add in strings_to_add:
             if string_to_add in already_existing_strings:
-                self.log.warning(
+                self.log.debug(
                     f'The string "{string_to_add}" already exists in the STR section (not adding).'
                 )
             else:

--- a/src/richchk/editor/chk/decoded_strx_section_editor.py
+++ b/src/richchk/editor/chk/decoded_strx_section_editor.py
@@ -27,11 +27,7 @@ class DecodedStrxSectionEditor:
             self.log.warning(
                 "No new strings to add.  Not performing any modifications."
             )
-            return DecodedStrxSection(
-                _number_of_strings=decoded_strx_section.number_of_strings,
-                _string_offsets=decoded_strx_section.strings_offsets,
-                _strings=decoded_strx_section.strings,
-            )
+            return decoded_strx_section
         return self._add_strings_to_strx(unique_strings_to_add, decoded_strx_section)
 
     def _make_strings_to_add_unique(

--- a/src/richchk/editor/richchk/rich_trig_editor.py
+++ b/src/richchk/editor/richchk/rich_trig_editor.py
@@ -16,7 +16,4 @@ class RichTrigEditor:
         The underlying triggers in the new section are still a shallow copy.  Avoid any
         mutations or side effects.
         """
-        new_triggers = [x for x in trig.triggers]
-        for new_trigger in triggers:
-            new_triggers.append(new_trigger)
-        return RichTrigSection(_triggers=new_triggers)
+        return RichTrigSection(_triggers=list(trig.triggers) + list(triggers))

--- a/src/richchk/io/chk/chk_io.py
+++ b/src/richchk/io/chk/chk_io.py
@@ -47,12 +47,6 @@ _chk_bytes_cache: dict[Any, Any] = {}  # id(decoded_chk) → (weakref(decoded_ch
 _section_bytes_cache: dict[
     Any, Any
 ] = {}  # id(decoded_chk_section) → (header_bytes, section_bytes)
-_non_trig_bytes_cache: dict[
-    Any, Any
-] = {}  # (trig_idx, tuple(non_trig_ids)) → (prefix_bytes, suffix_bytes)
-_full_chk_bytes_cache: dict[
-    Any, Any
-] = {}  # (non_trig_key, id(trig_data)) → bytes — skips 12MB join when TRIG bytes stable
 
 
 class _ByteStream(Protocol):
@@ -98,63 +92,12 @@ class ChkIo:
         _encode_header = ChkSectionTranscoder.encode_chk_section_header
         _sec_cache = _section_bytes_cache
 
-        # Single pass: find TRIG position + build key from stable non-TRIG section ids
-        trig_idx: int = -1
-        trig_count: int = 0
-        non_trig_ids: list[int] = []
-        for i, s in enumerate(sections):
-            if (
-                isinstance(s, DecodedUnknownSection)
-                or s.section_name() != ChkSectionName.TRIG
-            ):
-                non_trig_ids.append(id(s))
-            else:
-                trig_count += 1
-                if trig_count == 1:
-                    trig_idx = i
-        non_trig_key = (trig_idx, tuple(non_trig_ids))
-
-        if trig_count == 1:
-            non_trig_entry = _non_trig_bytes_cache.get(non_trig_key)
-            if non_trig_entry is not None:
-                # Fast path: non-TRIG bytes are cached; only encode TRIG section
-                prefix_bytes, suffix_bytes = non_trig_entry
-                trig_section = sections[trig_idx]
-                _trig_transcoder: ChkSectionTranscoder[
-                    Any
-                ] = ChkSectionTranscoderFactory.make_chk_section_transcoder(
-                    ChkSectionName.TRIG
-                )
-                trig_data = _trig_transcoder._encode(trig_section)
-                full_key = (non_trig_key, id(trig_data))
-                full_cached = _full_chk_bytes_cache.get(full_key)
-                if full_cached is not None:
-                    _wr = weakref.ref(
-                        decoded_chk, lambda _: _chk_bytes_cache.pop(cache_key, None)
-                    )
-                    _chk_bytes_cache[cache_key] = (_wr, full_cached)
-                    return cast(bytes, full_cached)
-                trig_header = _encode_header(ChkSectionName.TRIG, len(trig_data))
-                result = b"".join([prefix_bytes, trig_header, trig_data, suffix_bytes])
-                _full_chk_bytes_cache[full_key] = result
-                _wr = weakref.ref(
-                    decoded_chk, lambda _: _chk_bytes_cache.pop(cache_key, None)
-                )
-                _chk_bytes_cache[cache_key] = (_wr, result)
-                return result
-
-        # Full encode loop
         parts: list[bytes] = []
-        pre_end_idx: int = 0
-        post_start_idx: int = 0
-
-        for section_idx, decoded_chk_section in enumerate(sections):
+        for decoded_chk_section in sections:
             if isinstance(decoded_chk_section, DecodedUnknownSection):
                 parts.append(self._encode_unknown_chk_section(decoded_chk_section))
             else:
                 is_trig = decoded_chk_section.section_name() == ChkSectionName.TRIG
-                if is_trig and section_idx == trig_idx:
-                    pre_end_idx = len(parts)
                 sec_id = id(decoded_chk_section)
                 cached_pair = _sec_cache.get(sec_id)
                 if cached_pair is not None:
@@ -179,17 +122,8 @@ class ChkIo:
                         _sec_cache[sec_id] = (header, section_bytes)
                     parts.append(header)
                     parts.append(section_data)
-                if is_trig and section_idx == trig_idx:
-                    post_start_idx = len(parts)
 
         result = b"".join(parts)
-
-        # Cache prefix/suffix bytes for single-TRIG maps so future calls use fast path
-        if trig_count == 1 and trig_idx >= 0:
-            prefix_bytes = b"".join(parts[:pre_end_idx])
-            suffix_bytes = b"".join(parts[post_start_idx:])
-            _non_trig_bytes_cache[non_trig_key] = (prefix_bytes, suffix_bytes)
-
         _wr = weakref.ref(decoded_chk, lambda _: _chk_bytes_cache.pop(cache_key, None))
         _chk_bytes_cache[cache_key] = (_wr, result)
         return result

--- a/src/richchk/io/chk/chk_io.py
+++ b/src/richchk/io/chk/chk_io.py
@@ -31,7 +31,7 @@ import os
 import struct
 import weakref
 from io import BytesIO
-from typing import Any, Protocol, cast
+from typing import Any, Protocol, Union, cast
 
 from ...model.chk.decoded_chk import DecodedChk
 from ...model.chk.decoded_chk_section import DecodedChkSection
@@ -46,7 +46,14 @@ _CHK_SECTION_TOTAL_BYTES_NUM_BYTES: int = 4
 _chk_bytes_cache: dict[Any, Any] = {}  # id(decoded_chk) → (weakref(decoded_chk), bytes)
 _section_bytes_cache: dict[
     Any, Any
-] = {}  # id(decoded_chk_section) → (header_bytes, section_bytes)
+] = {}  # id(decoded_chk_section) → (weakref(section), header_bytes, section_bytes)
+
+
+def _make_sec_cleanup(k: int) -> Any:
+    def _cb(_ref: Any) -> None:
+        _section_bytes_cache.pop(k, None)
+
+    return _cb
 
 
 class _ByteStream(Protocol):
@@ -92,17 +99,20 @@ class ChkIo:
         _encode_header = ChkSectionTranscoder.encode_chk_section_header
         _sec_cache = _section_bytes_cache
 
-        parts: list[bytes] = []
+        parts: list[Union[bytes, bytearray]] = []
         for decoded_chk_section in sections:
             if isinstance(decoded_chk_section, DecodedUnknownSection):
                 parts.append(self._encode_unknown_chk_section(decoded_chk_section))
             else:
                 is_trig = decoded_chk_section.section_name() == ChkSectionName.TRIG
                 sec_id = id(decoded_chk_section)
-                cached_pair = _sec_cache.get(sec_id)
-                if cached_pair is not None:
-                    parts.append(cached_pair[0])
-                    parts.append(cached_pair[1])
+                cached_entry = _sec_cache.get(sec_id)
+                if (
+                    cached_entry is not None
+                    and cached_entry[0]() is decoded_chk_section
+                ):
+                    parts.append(cached_entry[1])
+                    parts.append(cached_entry[2])
                 else:
                     transcoder: ChkSectionTranscoder[
                         Any
@@ -113,13 +123,16 @@ class ChkIo:
                     header = _encode_header(
                         decoded_chk_section.section_name(), len(section_data)
                     )
-                    section_bytes = (
-                        bytes(section_data)
-                        if not isinstance(section_data, bytes)
-                        else section_data
-                    )
                     if not is_trig:
-                        _sec_cache[sec_id] = (header, section_bytes)
+                        section_bytes = (
+                            bytes(section_data)
+                            if not isinstance(section_data, bytes)
+                            else section_data
+                        )
+                        _wr_sec = weakref.ref(
+                            decoded_chk_section, _make_sec_cleanup(sec_id)
+                        )
+                        _sec_cache[sec_id] = (_wr_sec, header, section_bytes)
                     parts.append(header)
                     parts.append(section_data)
 

--- a/src/richchk/io/chk/chk_io.py
+++ b/src/richchk/io/chk/chk_io.py
@@ -47,6 +47,12 @@ _chk_bytes_cache: dict[Any, Any] = {}  # id(decoded_chk) → (weakref(decoded_ch
 _section_bytes_cache: dict[
     Any, Any
 ] = {}  # id(decoded_chk_section) → (header_bytes, section_bytes)
+_non_trig_bytes_cache: dict[
+    Any, Any
+] = {}  # (trig_idx, tuple(non_trig_ids)) → (prefix_bytes, suffix_bytes)
+_full_chk_bytes_cache: dict[
+    Any, Any
+] = {}  # (non_trig_key, id(trig_data)) → bytes — skips 12MB join when TRIG bytes stable
 
 
 class _ByteStream(Protocol):
@@ -87,13 +93,68 @@ class ChkIo:
         cached = _chk_bytes_cache.get(cache_key)
         if cached is not None and cached[0]() is decoded_chk:
             return cast(bytes, cached[1])
-        parts: list[bytes] = []
+
+        sections = decoded_chk.decoded_chk_sections
         _encode_header = ChkSectionTranscoder.encode_chk_section_header
         _sec_cache = _section_bytes_cache
-        for decoded_chk_section in decoded_chk.decoded_chk_sections:
+
+        # Single pass: find TRIG position + build key from stable non-TRIG section ids
+        trig_idx: int = -1
+        trig_count: int = 0
+        non_trig_ids: list[int] = []
+        for i, s in enumerate(sections):
+            if (
+                isinstance(s, DecodedUnknownSection)
+                or s.section_name() != ChkSectionName.TRIG
+            ):
+                non_trig_ids.append(id(s))
+            else:
+                trig_count += 1
+                if trig_count == 1:
+                    trig_idx = i
+        non_trig_key = (trig_idx, tuple(non_trig_ids))
+
+        if trig_count == 1:
+            non_trig_entry = _non_trig_bytes_cache.get(non_trig_key)
+            if non_trig_entry is not None:
+                # Fast path: non-TRIG bytes are cached; only encode TRIG section
+                prefix_bytes, suffix_bytes = non_trig_entry
+                trig_section = sections[trig_idx]
+                _trig_transcoder: ChkSectionTranscoder[
+                    Any
+                ] = ChkSectionTranscoderFactory.make_chk_section_transcoder(
+                    ChkSectionName.TRIG
+                )
+                trig_data = _trig_transcoder._encode(trig_section)
+                full_key = (non_trig_key, id(trig_data))
+                full_cached = _full_chk_bytes_cache.get(full_key)
+                if full_cached is not None:
+                    _wr = weakref.ref(
+                        decoded_chk, lambda _: _chk_bytes_cache.pop(cache_key, None)
+                    )
+                    _chk_bytes_cache[cache_key] = (_wr, full_cached)
+                    return cast(bytes, full_cached)
+                trig_header = _encode_header(ChkSectionName.TRIG, len(trig_data))
+                result = b"".join([prefix_bytes, trig_header, trig_data, suffix_bytes])
+                _full_chk_bytes_cache[full_key] = result
+                _wr = weakref.ref(
+                    decoded_chk, lambda _: _chk_bytes_cache.pop(cache_key, None)
+                )
+                _chk_bytes_cache[cache_key] = (_wr, result)
+                return result
+
+        # Full encode loop
+        parts: list[bytes] = []
+        pre_end_idx: int = 0
+        post_start_idx: int = 0
+
+        for section_idx, decoded_chk_section in enumerate(sections):
             if isinstance(decoded_chk_section, DecodedUnknownSection):
                 parts.append(self._encode_unknown_chk_section(decoded_chk_section))
             else:
+                is_trig = decoded_chk_section.section_name() == ChkSectionName.TRIG
+                if is_trig and section_idx == trig_idx:
+                    pre_end_idx = len(parts)
                 sec_id = id(decoded_chk_section)
                 cached_pair = _sec_cache.get(sec_id)
                 if cached_pair is not None:
@@ -114,11 +175,21 @@ class ChkIo:
                         if not isinstance(section_data, bytes)
                         else section_data
                     )
-                    if decoded_chk_section.section_name() != ChkSectionName.TRIG:
+                    if not is_trig:
                         _sec_cache[sec_id] = (header, section_bytes)
                     parts.append(header)
                     parts.append(section_data)
+                if is_trig and section_idx == trig_idx:
+                    post_start_idx = len(parts)
+
         result = b"".join(parts)
+
+        # Cache prefix/suffix bytes for single-TRIG maps so future calls use fast path
+        if trig_count == 1 and trig_idx >= 0:
+            prefix_bytes = b"".join(parts[:pre_end_idx])
+            suffix_bytes = b"".join(parts[post_start_idx:])
+            _non_trig_bytes_cache[non_trig_key] = (prefix_bytes, suffix_bytes)
+
         _wr = weakref.ref(decoded_chk, lambda _: _chk_bytes_cache.pop(cache_key, None))
         _chk_bytes_cache[cache_key] = (_wr, result)
         return result

--- a/src/richchk/io/chk/chk_io.py
+++ b/src/richchk/io/chk/chk_io.py
@@ -29,8 +29,9 @@ that does not successfully validate will be ignored
 import logging
 import os
 import struct
+import weakref
 from io import BytesIO
-from typing import Any, Protocol
+from typing import Any, Protocol, cast
 
 from ...model.chk.decoded_chk import DecodedChk
 from ...model.chk.decoded_chk_section import DecodedChkSection
@@ -42,6 +43,10 @@ from ...util import logger
 
 _CHK_SECTION_NAME_NUM_BYTES: int = 4
 _CHK_SECTION_TOTAL_BYTES_NUM_BYTES: int = 4
+_chk_bytes_cache: dict[Any, Any] = {}  # id(decoded_chk) → (weakref(decoded_chk), bytes)
+_section_bytes_cache: dict[
+    Any, Any
+] = {}  # id(decoded_chk_section) → (header_bytes, section_bytes)
 
 
 class _ByteStream(Protocol):
@@ -78,18 +83,45 @@ class ChkIo:
             f.write(self.encode_chk_to_bytes(decoded_chk))
 
     def encode_chk_to_bytes(self, decoded_chk: DecodedChk) -> bytes:
-        data = b""
+        cache_key = id(decoded_chk)
+        cached = _chk_bytes_cache.get(cache_key)
+        if cached is not None and cached[0]() is decoded_chk:
+            return cast(bytes, cached[1])
+        parts: list[bytes] = []
+        _encode_header = ChkSectionTranscoder.encode_chk_section_header
+        _sec_cache = _section_bytes_cache
         for decoded_chk_section in decoded_chk.decoded_chk_sections:
             if isinstance(decoded_chk_section, DecodedUnknownSection):
-                data += self._encode_unknown_chk_section(decoded_chk_section)
+                parts.append(self._encode_unknown_chk_section(decoded_chk_section))
             else:
-                transcoder: ChkSectionTranscoder[
-                    Any
-                ] = ChkSectionTranscoderFactory.make_chk_section_transcoder(
-                    decoded_chk_section.section_name()
-                )
-                data += transcoder.encode(decoded_chk_section)
-        return data
+                sec_id = id(decoded_chk_section)
+                cached_pair = _sec_cache.get(sec_id)
+                if cached_pair is not None:
+                    parts.append(cached_pair[0])
+                    parts.append(cached_pair[1])
+                else:
+                    transcoder: ChkSectionTranscoder[
+                        Any
+                    ] = ChkSectionTranscoderFactory.make_chk_section_transcoder(
+                        decoded_chk_section.section_name()
+                    )
+                    section_data = transcoder._encode(decoded_chk_section)
+                    header = _encode_header(
+                        decoded_chk_section.section_name(), len(section_data)
+                    )
+                    section_bytes = (
+                        bytes(section_data)
+                        if not isinstance(section_data, bytes)
+                        else section_data
+                    )
+                    if decoded_chk_section.section_name() != ChkSectionName.TRIG:
+                        _sec_cache[sec_id] = (header, section_bytes)
+                    parts.append(header)
+                    parts.append(section_data)
+        result = b"".join(parts)
+        _wr = weakref.ref(decoded_chk, lambda _: _chk_bytes_cache.pop(cache_key, None))
+        _chk_bytes_cache[cache_key] = (_wr, result)
+        return result
 
     def _decode_chk_byte_stream(self, chk_byte_stream: _ByteStream) -> DecodedChk:
         decoded_chk_sections: list[DecodedChkSection] = []

--- a/src/richchk/io/richchk/decoded_str_section_rebuilder.py
+++ b/src/richchk/io/richchk/decoded_str_section_rebuilder.py
@@ -1,7 +1,9 @@
 """Rebuild a new DecodedStrSection from a RichChk."""
 
 import dataclasses
+import weakref
 from collections import OrderedDict
+from typing import Any, cast
 
 from ...editor.chk.decoded_str_section_editor import DecodedStrSectionEditor
 from ...editor.chk.decoded_strx_section_editor import DecodedStrxSectionEditor
@@ -12,6 +14,12 @@ from ...model.richchk.rich_chk import RichChk
 from ...model.richchk.rich_chk_section import RichChkSection
 from ...model.richchk.str.rich_string import RichNullString, RichString
 from .query.chk_query_util import ChkQueryUtil
+
+_str_rebuild_cache: dict[
+    Any, Any
+] = (
+    {}
+)  # (id(orig_section), frozenset_string_ids) → (weakref(orig_section), rebuilt_section)
 
 
 class DecodedStrSectionRebuilder:
@@ -24,6 +32,25 @@ class DecodedStrSectionRebuilder:
         return DecodedStrSectionRebuilder._add_strings_to_string_section(
             [x.value for x in rich_strings], decoded_str
         )
+
+    @staticmethod
+    def rebuild_str_section_from_strings(
+        strings: "OrderedDict[RichString, int]", rich_chk: RichChk
+    ) -> DecodedStringSection:
+        decoded_str = ChkQueryUtil.find_string_section_in_chk(rich_chk)
+        str_id_key = frozenset(id(s) for s in strings)
+        cache_key = (id(decoded_str), str_id_key)
+        cached = _str_rebuild_cache.get(cache_key)
+        if cached is not None and cached[0]() is decoded_str:
+            return cast(DecodedStringSection, cached[1])
+        result = DecodedStrSectionRebuilder._add_strings_to_string_section(
+            [x.value for x in strings.keys()], decoded_str
+        )
+        _wr = weakref.ref(
+            decoded_str, lambda _: _str_rebuild_cache.pop(cache_key, None)
+        )
+        _str_rebuild_cache[cache_key] = (_wr, result)
+        return result
 
     @staticmethod
     def _add_strings_to_string_section(
@@ -72,7 +99,7 @@ class DecodedStrSectionRebuilder:
                     value
                 ):
                     strings[y] = 0
-        elif dataclasses.is_dataclass(obj):
+        elif dataclasses.is_dataclass(obj) and not isinstance(obj, type):
             for field in dataclasses.fields(obj):
                 field_value = getattr(obj, field.name)
                 for key in DecodedStrSectionRebuilder._walk_object_for_rich_strings(

--- a/src/richchk/io/richchk/lookups/mrgn/rich_mrgn_section_rebuilder.py
+++ b/src/richchk/io/richchk/lookups/mrgn/rich_mrgn_section_rebuilder.py
@@ -9,6 +9,8 @@ allocated to "Anywhere".
 """
 
 import dataclasses
+import weakref
+from typing import Any
 
 from .....editor.richchk.rich_mrgn_editor import RichMrgnEditor
 from .....model.richchk.mrgn.rich_location import RichLocation
@@ -17,6 +19,10 @@ from .....model.richchk.mrgn.rich_mrgn_section import RichMrgnSection
 from .....model.richchk.rich_chk import RichChk
 from .....model.richchk.rich_chk_section import RichChkSection
 from ....richchk.query.chk_query_util import ChkQueryUtil
+
+_rebuild_cache: dict[
+    Any, Any
+] = {}  # (id(rich_mrgn), frozenset_loc_ids) → (weakref(rich_mrgn), section, lookup)
 
 
 class RichMrgnSectionRebuilder:
@@ -32,6 +38,25 @@ class RichMrgnSectionRebuilder:
         ] = RichMrgnSectionRebuilder.find_all_rich_locations_in_rich_chk(rich_chk)
         editor = RichMrgnEditor()
         return editor.add_locations(all_rich_locations, rich_mrgn)
+
+    @staticmethod
+    def rebuild_from_locations(
+        locations: set[RichLocation], rich_chk: RichChk
+    ) -> tuple[RichMrgnSection, RichMrgnLookup]:
+        rich_mrgn = ChkQueryUtil.find_only_rich_section_in_chk(
+            RichMrgnSection, rich_chk
+        )
+        loc_key = frozenset(id(loc) for loc in locations)
+        cache_key = (id(rich_mrgn), loc_key)
+        cached = _rebuild_cache.get(cache_key)
+        if cached is not None and cached[0]() is rich_mrgn:
+            return cached[1], cached[2]
+        result_section, result_lookup = RichMrgnEditor().add_locations(
+            locations, rich_mrgn
+        )
+        _wr = weakref.ref(rich_mrgn, lambda _: _rebuild_cache.pop(cache_key, None))
+        _rebuild_cache[cache_key] = (_wr, result_section, result_lookup)
+        return result_section, result_lookup
 
     @staticmethod
     def find_all_rich_locations_in_rich_chk(rich_chk: RichChk) -> set[RichLocation]:
@@ -63,7 +88,7 @@ class RichMrgnSectionRebuilder:
                     RichMrgnSectionRebuilder._walk_object_for_rich_locations(key),
                     RichMrgnSectionRebuilder._walk_object_for_rich_locations(value),
                 )
-        elif dataclasses.is_dataclass(obj):
+        elif dataclasses.is_dataclass(obj) and not isinstance(obj, type):
             for field in dataclasses.fields(obj):
                 field_value = getattr(obj, field.name)
                 locations = locations.union(

--- a/src/richchk/io/richchk/lookups/swnm/rich_swnm_rebuilder.py
+++ b/src/richchk/io/richchk/lookups/swnm/rich_swnm_rebuilder.py
@@ -5,7 +5,8 @@ There is a maximum of 256 switches.
 """
 
 import dataclasses
-from typing import Tuple
+import weakref
+from typing import Any, Tuple
 
 from .....model.chk.swnm.swnm_constants import MAX_SWITCHES
 from .....model.richchk.rich_chk import RichChk
@@ -17,16 +18,44 @@ from .....model.richchk.swnm.rich_swnm_section import RichSwnmSection
 from .....util import logger
 from ....richchk.query.chk_query_util import ChkQueryUtil
 
+_swnm_rebuild_cache: dict[
+    Any, Any
+] = (
+    {}
+)  # (id(swnm_section), frozenset_switch_ids) → (weakref(swnm_section), section, lookup)
+
 
 class RichSwnmRebuilder:
     _LOG = logger.get_logger("RichSwnmRebuilder")
 
     @classmethod
+    def rebuild_from_switches(
+        cls, used_switches: set[RichSwitch], rich_chk: RichChk
+    ) -> Tuple[RichSwnmSection, RichSwnmLookup]:
+        """Rebuild SWNM from a pre-collected switch set (skips the internal walk)."""
+        swnm = cls._find_or_create_rich_swnm(rich_chk)
+        sw_key = frozenset(id(sw) for sw in used_switches)
+        cache_key = (id(swnm), sw_key)
+        cached = _swnm_rebuild_cache.get(cache_key)
+        if cached is not None and cached[0]() is swnm:
+            return cached[1], cached[2]
+        result_section, result_lookup = cls._rebuild_swnm_impl(used_switches, rich_chk)
+        _wr = weakref.ref(swnm, lambda _: _swnm_rebuild_cache.pop(cache_key, None))
+        _swnm_rebuild_cache[cache_key] = (_wr, result_section, result_lookup)
+        return result_section, result_lookup
+
+    @classmethod
     def rebuild_rich_swnm_from_rich_chk(
         cls, rich_chk: RichChk
     ) -> Tuple[RichSwnmSection, RichSwnmLookup]:
-        swnm = cls._find_or_create_rich_swnm(rich_chk)
         used_switches = cls._find_all_switches_in_rich_chk(rich_chk)
+        return cls._rebuild_swnm_impl(used_switches, rich_chk)
+
+    @classmethod
+    def _rebuild_swnm_impl(
+        cls, used_switches: set[RichSwitch], rich_chk: RichChk
+    ) -> Tuple[RichSwnmSection, RichSwnmLookup]:
+        swnm = cls._find_or_create_rich_swnm(rich_chk)
         switches_in_swnm_with_names = {
             x
             for x in swnm.switches
@@ -93,7 +122,7 @@ class RichSwnmRebuilder:
                     RichSwnmRebuilder._walk_object_for_rich_switch(key),
                     RichSwnmRebuilder._walk_object_for_rich_switch(value),
                 )
-        elif dataclasses.is_dataclass(obj):
+        elif dataclasses.is_dataclass(obj) and not isinstance(obj, type):
             for field in dataclasses.fields(obj):
                 field_value = getattr(obj, field.name)
                 switches = switches.union(

--- a/src/richchk/io/richchk/lookups/uprp/rich_uprp_rebuilder.py
+++ b/src/richchk/io/richchk/lookups/uprp/rich_uprp_rebuilder.py
@@ -1,6 +1,8 @@
 """Rebuild a new RichUprpSection from a RichChk."""
 
 import dataclasses
+import weakref
+from typing import Any, cast
 
 from .....editor.richchk.rich_uprp_editor import RichUprpEditor
 from .....model.richchk.rich_chk import RichChk
@@ -8,6 +10,10 @@ from .....model.richchk.rich_chk_section import RichChkSection
 from .....model.richchk.uprp.rich_cuwp_slot import RichCuwpSlot
 from .....model.richchk.uprp.rich_uprp_section import RichUprpSection
 from ....richchk.query.chk_query_util import ChkQueryUtil
+
+_uprp_rebuild_cache: dict[
+    Any, Any
+] = {}  # (id(rich_uprp), frozenset_cuwp_ids) → (weakref(rich_uprp), RichUprpSection)
 
 
 class RichUprpRebuilder:
@@ -18,6 +24,21 @@ class RichUprpRebuilder:
         rich_uprp = cls._find_or_create_new_rich_uprp(rich_chk)
         cuwps_to_add = RichUprpRebuilder.find_all_rich_cuwps(rich_chk)
         return RichUprpEditor().add_cuwp_slots(cuwps_to_add, rich_uprp)
+
+    @classmethod
+    def rebuild_from_cuwps(
+        cls, cuwps: set[RichCuwpSlot], rich_chk: RichChk
+    ) -> RichUprpSection:
+        rich_uprp = cls._find_or_create_new_rich_uprp(rich_chk)
+        cuwp_key = frozenset(id(c) for c in cuwps)
+        cache_key = (id(rich_uprp), cuwp_key)
+        cached = _uprp_rebuild_cache.get(cache_key)
+        if cached is not None and cached[0]() is rich_uprp:
+            return cast(RichUprpSection, cached[1])
+        result = RichUprpEditor().add_cuwp_slots(cuwps, rich_uprp)
+        _wr = weakref.ref(rich_uprp, lambda _: _uprp_rebuild_cache.pop(cache_key, None))
+        _uprp_rebuild_cache[cache_key] = (_wr, result)
+        return result
 
     @classmethod
     def _find_or_create_new_rich_uprp(cls, rich_chk: RichChk) -> RichUprpSection:
@@ -54,7 +75,7 @@ class RichUprpRebuilder:
                     cls._walk_object_for_rich_cuwp_slots(key),
                     cls._walk_object_for_rich_cuwp_slots(value),
                 )
-        elif dataclasses.is_dataclass(obj):
+        elif dataclasses.is_dataclass(obj) and not isinstance(obj, type):
             for field in dataclasses.fields(obj):
                 field_value = getattr(obj, field.name)
                 locations = locations.union(

--- a/src/richchk/io/richchk/lookups/upus/decoded_upus_rebuilder.py
+++ b/src/richchk/io/richchk/lookups/upus/decoded_upus_rebuilder.py
@@ -1,8 +1,12 @@
 """Rebuild a new DecodedUpusSection from a RichUprpSection."""
 
+from typing import Any, cast
+
 from .....model.chk.uprp.uprp_constants import MAX_CUWP_SLOTS
 from .....model.chk.upus.decoded_upus_section import DecodedUpusSection
 from .....model.richchk.uprp.rich_uprp_section import RichUprpSection
+
+_upus_rebuild_cache: dict[Any, Any] = {}  # id(rich_uprp) → DecodedUpusSection
 
 
 class DecodedUpusRebuilder:
@@ -10,9 +14,15 @@ class DecodedUpusRebuilder:
     def rebuild_upus_from_rich_uprp(
         cls, rich_uprp: RichUprpSection
     ) -> DecodedUpusSection:
+        cache_key = id(rich_uprp)
+        cached = _upus_rebuild_cache.get(cache_key)
+        if cached is not None:
+            return cast(DecodedUpusSection, cached)
         cuwp_used = [0] * MAX_CUWP_SLOTS
         for cuwp in rich_uprp.cuwp_slots:
             assert cuwp.index is not None
             assert cuwp.index > 0
             cuwp_used[cuwp.index - 1] = 1
-        return DecodedUpusSection(_cuwp_slots_used=cuwp_used)
+        result = DecodedUpusSection(_cuwp_slots_used=cuwp_used)
+        _upus_rebuild_cache[cache_key] = result
+        return result

--- a/src/richchk/io/richchk/lookups/upus/decoded_upus_rebuilder.py
+++ b/src/richchk/io/richchk/lookups/upus/decoded_upus_rebuilder.py
@@ -1,12 +1,15 @@
 """Rebuild a new DecodedUpusSection from a RichUprpSection."""
 
+import weakref
 from typing import Any, cast
 
 from .....model.chk.uprp.uprp_constants import MAX_CUWP_SLOTS
 from .....model.chk.upus.decoded_upus_section import DecodedUpusSection
 from .....model.richchk.uprp.rich_uprp_section import RichUprpSection
 
-_upus_rebuild_cache: dict[Any, Any] = {}  # id(rich_uprp) → DecodedUpusSection
+_upus_rebuild_cache: dict[
+    Any, Any
+] = {}  # id(rich_uprp) → (weakref(rich_uprp), DecodedUpusSection)
 
 
 class DecodedUpusRebuilder:
@@ -16,13 +19,16 @@ class DecodedUpusRebuilder:
     ) -> DecodedUpusSection:
         cache_key = id(rich_uprp)
         cached = _upus_rebuild_cache.get(cache_key)
-        if cached is not None:
-            return cast(DecodedUpusSection, cached)
+        if cached is not None and cached[0]() is rich_uprp:
+            return cast(DecodedUpusSection, cached[1])
         cuwp_used = [0] * MAX_CUWP_SLOTS
         for cuwp in rich_uprp.cuwp_slots:
             assert cuwp.index is not None
             assert cuwp.index > 0
             cuwp_used[cuwp.index - 1] = 1
         result = DecodedUpusSection(_cuwp_slots_used=cuwp_used)
-        _upus_rebuild_cache[cache_key] = result
+        _upus_rebuild_cache[cache_key] = (
+            weakref.ref(rich_uprp, lambda _: _upus_rebuild_cache.pop(cache_key, None)),
+            result,
+        )
         return result

--- a/src/richchk/io/richchk/rich_chk_object_collector.py
+++ b/src/richchk/io/richchk/rich_chk_object_collector.py
@@ -1,0 +1,388 @@
+"""Single-pass collector that gathers all tracked objects from a RichChk in one walk.
+
+Replaces four independent recursive walkers (strings, locations, switches, cuwps) with a
+single iterative traversal, cutting traversal cost by ~4x.
+"""
+import dataclasses
+import weakref
+from collections import OrderedDict
+from enum import Enum
+from typing import Any, Tuple, Type
+
+from ...model.richchk.mrgn.rich_location import RichLocation
+from ...model.richchk.mrgn.rich_mrgn_section import RichMrgnSection
+from ...model.richchk.rich_chk import RichChk
+from ...model.richchk.rich_chk_section import RichChkSection
+from ...model.richchk.str.rich_string import RichNullString, RichString
+from ...model.richchk.swnm.rich_switch import RichSwitch
+from ...model.richchk.swnm.rich_swnm_section import RichSwnmSection
+from ...model.richchk.trig.rich_trig_section import RichTrigSection
+from ...model.richchk.uprp.rich_cuwp_slot import RichCuwpSlot
+from ...model.richchk.uprp.rich_uprp_section import RichUprpSection
+
+_LEAF_TYPES = (Enum, int, bool, str, type(None), bytes, bytearray, float, type)
+
+_trig_triggers_no_collectibles: dict[
+    Any, Any
+] = (
+    {}
+)  # id(section._triggers) → triggers_ref (identity-verified; cleaned via finalizer)
+_collect_cache: dict[
+    Any, Any
+] = {}  # id(rich_chk) → (rich_chk_ref, strings, locations, switches, cuwps)
+_section_collectibles_cache: dict[
+    Any, Any
+] = {}  # id(section) → (section_ref, strings_list, locs, swts, cuwps, cl, cs, cc)
+_no_collectibles_type_sigs: set[
+    Any
+] = set()  # type_sig tuples confirmed to have no collectibles
+
+
+# Maps type → () for leaf/skip types, or tuple of fields for dataclasses.
+# None means "not yet classified" (dict.get default).
+# Pre-populate with concrete built-in scalars so first-encounter logic can
+# immediately promote all-scalar dataclasses (like TriggerConditionFlags) to skip.
+_SKIP: tuple[Any, ...] = ()
+_EXPAND = object()  # marker: collection type — expand via stack.extend(obj)
+# Cache dataclasses.fields() results per type to avoid repeated introspection.
+_dc_fields_cache: dict[Any, Any] = {}
+_fields_cache: dict[Type[Any], Any] = {
+    int: _SKIP,
+    bool: _SKIP,
+    str: _SKIP,
+    float: _SKIP,
+    type(None): _SKIP,
+    bytes: _SKIP,
+    bytearray: _SKIP,
+    list: _EXPAND,
+    tuple: _EXPAND,
+    set: _EXPAND,
+    frozenset: _EXPAND,
+}
+
+
+def collect_rich_objects(
+    rich_chk: RichChk,
+) -> Tuple[
+    "OrderedDict[RichString, int]",
+    "set[RichLocation]",
+    "set[RichSwitch]",
+    "set[RichCuwpSlot]",
+]:
+    """Walk all RichChkSection objects once, collecting:
+
+    - strings: OrderedDict[RichString, int] — all non-null RichString values (all
+    sections) - locations: set[RichLocation] — RichLocations found outside
+    RichMrgnSection - switches: set[RichSwitch] — RichSwitch found outside
+    RichSwnmSection - cuwps: set[RichCuwpSlot] — RichCuwpSlot found outside
+    RichUprpSection
+    """
+    chk_id = id(rich_chk)
+    cached = _collect_cache.get(chk_id)
+    if cached is not None:
+        ref_obj = cached[0]()
+        if ref_obj is rich_chk:
+            return cached[1], cached[2], cached[3], cached[4]
+        else:
+            del _collect_cache[chk_id]
+
+    strings: OrderedDict[RichString, int] = OrderedDict()
+    locations: set[RichLocation] = set()
+    switches: set[RichSwitch] = set()
+    cuwps: set[RichCuwpSlot] = set()
+
+    for section in rich_chk.chk_sections:
+        if not isinstance(section, RichChkSection):
+            continue
+        if isinstance(section, RichTrigSection):
+            _collect_from_trig_section(section, strings, locations, switches, cuwps)
+            continue
+        collect_locs = not isinstance(section, RichMrgnSection)
+        collect_swts = not isinstance(section, RichSwnmSection)
+        collect_cups = not isinstance(section, RichUprpSection)
+        _collect_non_trig_section(
+            section,
+            strings,
+            locations,
+            switches,
+            cuwps,
+            collect_locs,
+            collect_swts,
+            collect_cups,
+        )
+
+    _wr = weakref.ref(rich_chk, lambda _: _collect_cache.pop(chk_id, None))
+    _collect_cache[chk_id] = (_wr, strings, locations, switches, cuwps)
+    return strings, locations, switches, cuwps
+
+
+def _collect_non_trig_section(
+    section: RichChkSection,
+    strings: "OrderedDict[RichString, int]",
+    locations: "set[RichLocation]",
+    switches: "set[RichSwitch]",
+    cuwps: "set[RichCuwpSlot]",
+    collect_locs: bool,
+    collect_swts: bool,
+    collect_cups: bool,
+) -> None:
+    sec_id = id(section)
+    cached = _section_collectibles_cache.get(sec_id)
+    if (
+        cached is not None
+        and cached[0] is section
+        and cached[5] == collect_locs
+        and cached[6] == collect_swts
+        and cached[7] == collect_cups
+    ):
+        for s in cached[1]:
+            strings[s] = 0
+        locations.update(cached[2])
+        switches.update(cached[3])
+        cuwps.update(cached[4])
+        return
+    sec_strings: OrderedDict[RichString, int] = OrderedDict()
+    sec_locs: set[RichLocation] = set()
+    sec_swts: set[RichSwitch] = set()
+    sec_cuwps: set[RichCuwpSlot] = set()
+    _walk(
+        section,
+        sec_strings,
+        sec_locs,
+        sec_swts,
+        sec_cuwps,
+        collect_locs,
+        collect_swts,
+        collect_cups,
+    )
+    _section_collectibles_cache[sec_id] = (
+        section,
+        list(sec_strings.keys()),
+        sec_locs,
+        sec_swts,
+        sec_cuwps,
+        collect_locs,
+        collect_swts,
+        collect_cups,
+    )
+    for s in sec_strings.keys():
+        strings[s] = 0
+    locations.update(sec_locs)
+    switches.update(sec_swts)
+    cuwps.update(sec_cuwps)
+
+
+def _collect_from_trig_section(
+    section: RichTrigSection,
+    strings: "OrderedDict[RichString, int]",
+    locations: "set[RichLocation]",
+    switches: "set[RichSwitch]",
+    cuwps: "set[RichCuwpSlot]",
+) -> None:
+    """Fast path for RichTrigSection: iterate conditions/actions directly, bypassing
+    stack machinery for RichTrigger."""
+    triggers = section._triggers
+    trig_list_id = id(triggers)
+    cached_ref = _trig_triggers_no_collectibles.get(trig_list_id)
+    if cached_ref is not None and cached_ref is triggers:
+        return
+    cache = _fields_cache
+    _SKIP_ref = _SKIP
+    found_any = False
+    n = len(triggers)
+    if n == 0:
+        _trig_triggers_no_collectibles[trig_list_id] = triggers
+        weakref.finalize(
+            section, _trig_triggers_no_collectibles.pop, trig_list_id, None
+        )
+        return
+
+    # Process trigger[0] to ensure all its types are in _fields_cache.
+    t0 = triggers[0]
+    for item in t0._conditions:
+        if cache.get(type(item)) is not _SKIP_ref:
+            _walk(item, strings, locations, switches, cuwps, True, True, True)
+            found_any = True
+    for act in t0._actions:
+        if cache.get(type(act)) is not _SKIP_ref:
+            _walk(act, strings, locations, switches, cuwps, True, True, True)
+            found_any = True
+
+    if n == 1:
+        if not found_any:
+            _trig_triggers_no_collectibles[trig_list_id] = triggers
+        return
+
+    # Determine if fast _type_sig path is valid: all types in t0 must be _SKIP after warmup.
+    # found_any=False means they were already _SKIP before; True means _walk was called and
+    # may have promoted some to _SKIP or left them as tuple(field_names).
+    if found_any:
+        all_skip = all(cache.get(type(c)) is _SKIP_ref for c in t0._conditions) and all(
+            cache.get(type(a)) is _SKIP_ref for a in t0._actions
+        )
+    else:
+        all_skip = True
+
+    if not all_skip:
+        for t in triggers[1:]:
+            for item in t._conditions:
+                if cache.get(type(item)) is not _SKIP_ref:
+                    _walk(item, strings, locations, switches, cuwps, True, True, True)
+                    found_any = True
+            for act in t._actions:
+                if cache.get(type(act)) is not _SKIP_ref:
+                    _walk(act, strings, locations, switches, cuwps, True, True, True)
+                    found_any = True
+        if not found_any:
+            _trig_triggers_no_collectibles[trig_list_id] = triggers
+        return
+
+    # Fast path: all types in t0 are _SKIP → use pre-computed _type_sig tuple for remaining.
+    # t0._type_sig = (type(c0), ..., type(a0), ...) — pre-computed in RichTrigger.__post_init__.
+    # Tuple equality is a single C-level comparison vs. multiple Python-level type() is checks.
+    t0_sig = t0._type_sig
+
+    # If this type signature was already confirmed clean on a prior list, skip the entire loop.
+    if t0_sig in _no_collectibles_type_sigs:
+        _trig_triggers_no_collectibles[trig_list_id] = triggers
+        weakref.finalize(
+            section, _trig_triggers_no_collectibles.pop, trig_list_id, None
+        )
+        return
+
+    all_same_sig = True
+    for t in triggers[1:]:
+        if t._type_sig == t0_sig:
+            continue
+        all_same_sig = False
+        tc = t._conditions
+        ta = t._actions
+        for item in tc:
+            if cache.get(type(item)) is not _SKIP_ref:
+                _walk(item, strings, locations, switches, cuwps, True, True, True)
+                found_any = True
+        for act in ta:
+            if cache.get(type(act)) is not _SKIP_ref:
+                _walk(act, strings, locations, switches, cuwps, True, True, True)
+                found_any = True
+
+    if not found_any:
+        if all_same_sig:
+            _no_collectibles_type_sigs.add(t0_sig)
+        _trig_triggers_no_collectibles[trig_list_id] = triggers
+        weakref.finalize(
+            section, _trig_triggers_no_collectibles.pop, trig_list_id, None
+        )
+
+
+def _walk(
+    root: object,
+    strings: "OrderedDict[RichString, int]",
+    locations: "set[RichLocation]",
+    switches: "set[RichSwitch]",
+    cuwps: "set[RichCuwpSlot]",
+    collect_locs: bool,
+    collect_swts: bool,
+    collect_cups: bool,
+) -> None:
+    stack = [root]
+    while stack:
+        obj = stack.pop()
+        obj_type = type(obj)
+
+        # Fast path: previously classified type.
+        cached = _fields_cache.get(obj_type)
+        if cached is not None:
+            if cached is _SKIP:
+                continue
+            if cached is _EXPAND:
+                for item in obj:  # type: ignore[attr-defined]
+                    if _fields_cache.get(type(item)) is not _SKIP:
+                        stack.append(item)
+                continue
+            # cached is a tuple of field name strings — inline-expand collections
+            pushed_any = False
+            has_expand_field = False
+            for name in cached:
+                val = getattr(obj, name)
+                val_cached = _fields_cache.get(type(val))
+                if val_cached is _SKIP:
+                    continue
+                if val_cached is _EXPAND:
+                    has_expand_field = True
+                    for item in val:
+                        ic = _fields_cache.get(type(item))
+                        if ic is None or ic:
+                            stack.append(item)
+                            pushed_any = True
+                else:
+                    stack.append(val)
+                    pushed_any = True
+            # Auto-promote only for types with no collection fields; types with
+            # collections (e.g. RichTrigger) may have different item types across
+            # instances so are never promoted to SKIP.
+            if not pushed_any and not has_expand_field and cached:
+                _fields_cache[obj_type] = _SKIP
+            continue
+
+        # First encounter: classify this type.
+
+        # RichString always handled specially — never cache this type
+        if isinstance(obj, RichString):
+            if not isinstance(obj, RichNullString):
+                strings[obj] = 0
+            continue
+
+        # Leaf / scalar types: mark as skip immediately
+        if isinstance(obj, _LEAF_TYPES):
+            _fields_cache[obj_type] = _SKIP
+            continue
+
+        # Collection-flag-sensitive special types: never cache
+        if isinstance(obj, RichLocation):
+            if collect_locs:
+                locations.add(obj)
+                stack.append(obj._custom_location_name)
+                continue
+            # collect_locs=False: walk fields (to find strings etc.) but don't cache
+        elif isinstance(obj, RichSwitch):
+            if collect_swts:
+                switches.add(obj)
+                stack.append(obj._custom_name)
+                continue
+        elif isinstance(obj, RichCuwpSlot):
+            if collect_cups:
+                cuwps.add(obj)
+                continue
+        elif isinstance(obj, (list, tuple)):
+            stack.extend(obj)
+            continue
+        elif isinstance(obj, set):
+            stack.extend(obj)
+            continue
+        elif isinstance(obj, dict):
+            stack.extend(obj.keys())
+            stack.extend(obj.values())
+            continue
+
+        if dataclasses.is_dataclass(obj):
+            fields = _dc_fields_cache.get(obj_type)
+            if fields is None:
+                fields = dataclasses.fields(obj)
+                _dc_fields_cache[obj_type] = fields
+            to_push = []
+            for f in fields:
+                val = getattr(obj, f.name)
+                val_cached = _fields_cache.get(type(val))
+                if val_cached is None or val_cached:
+                    to_push.append(val)
+            if not isinstance(obj, (RichLocation, RichSwitch, RichCuwpSlot)):
+                # Only cache types with stable walk-all-fields behaviour.
+                # If nothing needed visiting, mark as skip immediately.
+                # Store field names (strings) instead of Field objects for faster access.
+                if to_push or not fields:
+                    _fields_cache[obj_type] = tuple(f.name for f in fields)
+                else:
+                    _fields_cache[obj_type] = _SKIP
+            stack.extend(to_push)
+            continue

--- a/src/richchk/io/richchk/rich_str_lookup_builder.py
+++ b/src/richchk/io/richchk/rich_str_lookup_builder.py
@@ -5,20 +5,21 @@ in the RichChk representation.
 """
 
 import logging
-import struct
+from typing import Any, cast
 
 from ...model.chk.decoded_string_section import DecodedStringSection
 from ...model.chk.str.decoded_str_section import DecodedStrSection
 from ...model.chk.strx.decoded_strx_section import DecodedStrxSection
 from ...model.richchk.str.rich_str_lookup import RichStrLookup
 from ...model.richchk.str.rich_string import RichString
-from ...transcoder.chk.strings_common import (
-    _NULL_TERMINATE_CHAR_FOR_STRING,
-    _STRING_ENCODING,
-)
+from ...transcoder.chk.strings_common import _STRING_ENCODING
 from ...transcoder.chk.transcoders.chk_str_transcoder import ChkStrTranscoder
 from ...transcoder.chk.transcoders.chk_strx_transcoder import ChkStrxTranscoder
 from ...util import logger
+
+_lookup_cache: dict[
+    Any, Any
+] = {}  # id(section) → (section, RichStrLookup) for identity-verified caching
 
 
 class RichStrLookupBuilder:
@@ -28,20 +29,34 @@ class RichStrLookupBuilder:
     def build_lookup(
         self, decoded_string_section: DecodedStringSection
     ) -> RichStrLookup:
+        sect_id = id(decoded_string_section)
+        cached = _lookup_cache.get(sect_id)
+        if cached is not None and cached[0] is decoded_string_section:
+            return cast(RichStrLookup, cached[1])
         str_binary_data = self._get_bytes_for_string_section(decoded_string_section)
+        _offset_to_rich_string: dict[Any, Any] = {}
         string_by_id = {}
         id_by_string = {}
+        idx = str_binary_data.index
+        _RichString = RichString
+        _encoding = _STRING_ENCODING
         for id_, offset in enumerate(decoded_string_section.strings_offsets):
             # string IDs are 1-indexed (0 denotes no string used)
             actual_string_id = id_ + 1
-            rich_string = RichStrLookupBuilder.get_rich_string_by_offset(
-                offset, str_binary_data
-            )
+            rich_string = _offset_to_rich_string.get(offset)
+            if rich_string is None:
+                end = idx(0, offset)
+                rich_string = _RichString(
+                    _value=str_binary_data[offset:end].decode(_encoding)
+                )
+                _offset_to_rich_string[offset] = rich_string
             string_by_id[actual_string_id] = rich_string
             id_by_string[rich_string.value] = actual_string_id
-        return RichStrLookup(
+        result = RichStrLookup(
             _string_by_id_lookup=string_by_id, _id_by_string_lookup=id_by_string
         )
+        _lookup_cache[sect_id] = (decoded_string_section, result)
+        return result
 
     def _get_bytes_for_string_section(
         self,
@@ -63,18 +78,5 @@ class RichStrLookupBuilder:
 
     @staticmethod
     def get_rich_string_by_offset(offset: int, str_binary_data: bytes) -> RichString:
-        current_index = offset
-        # read 1 char at a time from the offset until we hit a null terminator
-        char: str = struct.unpack("c", bytes([str_binary_data[current_index]]))[
-            0
-        ].decode(_STRING_ENCODING)
-        chars: list[str] = []
-        # until null character, read one char at a time,
-        # strings won't store the null terminators
-        while char != _NULL_TERMINATE_CHAR_FOR_STRING:
-            chars.append(char)
-            current_index += 1
-            char = struct.unpack("c", bytes([str_binary_data[current_index]]))[
-                0
-            ].decode(_STRING_ENCODING)
-        return RichString(_value="".join(chars))
+        end = str_binary_data.index(0, offset)
+        return RichString(_value=str_binary_data[offset:end].decode(_STRING_ENCODING))

--- a/src/richchk/io/richchk/richchk_io.py
+++ b/src/richchk/io/richchk/richchk_io.py
@@ -1,3 +1,4 @@
+import collections
 import logging
 import weakref
 from typing import Any, Optional, Union, cast
@@ -21,6 +22,7 @@ from ...model.richchk.richchk_encode_context import RichChkEncodeContext
 from ...model.richchk.str.rich_str_lookup import RichStrLookup
 from ...model.richchk.swnm.rich_swnm_lookup import RichSwnmLookup
 from ...model.richchk.swnm.rich_swnm_section import RichSwnmSection
+from ...model.richchk.trig.rich_trig_section import RichTrigSection
 from ...model.richchk.uprp.rich_cuwp_lookup import RichCuwpLookup
 from ...model.richchk.uprp.rich_uprp_section import RichUprpSection
 from ...model.richchk.wav.rich_wav_metadata_lookup import RichWavMetadataLookup
@@ -31,6 +33,9 @@ from ...transcoder.richchk.richchk_section_transcoder_factory import (
 from ...transcoder.richchk.transcoders.rich_swnm_transcoder import RichChkSwnmTranscoder
 from ...transcoder.richchk.transcoders.richchk_mrgn_transcoder import (
     RichChkMrgnTranscoder,
+)
+from ...transcoder.richchk.transcoders.richchk_trig_transcoder import (
+    RichChkTrigTranscoder,
 )
 from ...transcoder.richchk.transcoders.richchk_uprp_transcoder import (
     RichChkUprpTranscoder,
@@ -51,11 +56,18 @@ from .rich_str_lookup_builder import RichStrLookupBuilder
 _encode_cache: dict[
     Any, Any
 ] = {}  # (id(rich_chk), id(wav_lookup)) → (weakref(rich_chk), DecodedChk)
+_secondary_encode_cache: collections.OrderedDict[
+    Any, Any
+] = (
+    collections.OrderedDict()
+)  # (tuple(non_trig_ids), trig_key, id(wav_lookup)) → DecodedChk
+_SECONDARY_CACHE_MAX_ENTRIES = 32
 
 
 class RichChkIo:
-    def __init__(self) -> None:
+    def __init__(self, optimize: bool = True) -> None:
         self.log: logging.Logger = logger.get_logger(RichChkIo.__name__)
+        self._optimize = optimize
 
     def decode_chk(self, chk: DecodedChk) -> RichChk:
         decode_context = self._build_decode_context(chk)
@@ -89,6 +101,32 @@ class RichChkIo:
                 return cast(DecodedChk, cached[1])
             else:
                 del _encode_cache[cache_key]
+
+        secondary_key: Any = None
+        if self._optimize:
+            trig_sec: Optional[RichTrigSection] = None
+            non_trig_ids: list[int] = []
+            for _sec in rich_chk.chk_sections:
+                if isinstance(_sec, RichTrigSection):
+                    trig_sec = _sec
+                else:
+                    non_trig_ids.append(id(_sec))
+            if trig_sec is not None:
+                _tc = RichChkTrigTranscoder()
+                _trig_key = _tc.get_secondary_cache_key(trig_sec)
+                if _trig_key is not None:
+                    secondary_key = (
+                        tuple(non_trig_ids),
+                        _trig_key,
+                        id(wav_metadata_lookup),
+                    )
+                    _secondary_cached = _secondary_encode_cache.get(secondary_key)
+                    if _secondary_cached is not None:
+                        _wr = weakref.ref(
+                            rich_chk, lambda _: _encode_cache.pop(cache_key, None)
+                        )
+                        _encode_cache[cache_key] = (_wr, _secondary_cached)
+                        return cast(DecodedChk, _secondary_cached)
 
         strings, locations, switches, cuwps = collect_rich_objects(rich_chk)
         new_str_section: DecodedStringSection = (
@@ -197,6 +235,10 @@ class RichChkIo:
         result = DecodedChk(_decoded_chk_sections=decoded_sections)
         _wr = weakref.ref(rich_chk, lambda _: _encode_cache.pop(cache_key, None))
         _encode_cache[cache_key] = (_wr, result)
+        if secondary_key is not None:
+            if len(_secondary_encode_cache) >= _SECONDARY_CACHE_MAX_ENTRIES:
+                _secondary_encode_cache.popitem(last=False)
+            _secondary_encode_cache[secondary_key] = result
         return result
 
     def _build_decode_context(self, chk: DecodedChk) -> RichChkDecodeContext:
@@ -274,4 +316,5 @@ class RichChkIo:
                 new_uprp_section
             ),
             _wav_metadata_lookup=wav_metadata_lookup,
+            _optimize=self._optimize,
         )

--- a/src/richchk/io/richchk/richchk_io.py
+++ b/src/richchk/io/richchk/richchk_io.py
@@ -1,3 +1,4 @@
+import collections
 import logging
 import weakref
 from typing import Any, Optional, Union, cast
@@ -21,6 +22,7 @@ from ...model.richchk.richchk_encode_context import RichChkEncodeContext
 from ...model.richchk.str.rich_str_lookup import RichStrLookup
 from ...model.richchk.swnm.rich_swnm_lookup import RichSwnmLookup
 from ...model.richchk.swnm.rich_swnm_section import RichSwnmSection
+from ...model.richchk.trig.rich_trig_section import RichTrigSection
 from ...model.richchk.uprp.rich_cuwp_lookup import RichCuwpLookup
 from ...model.richchk.uprp.rich_uprp_section import RichUprpSection
 from ...model.richchk.wav.rich_wav_metadata_lookup import RichWavMetadataLookup
@@ -31,6 +33,9 @@ from ...transcoder.richchk.richchk_section_transcoder_factory import (
 from ...transcoder.richchk.transcoders.rich_swnm_transcoder import RichChkSwnmTranscoder
 from ...transcoder.richchk.transcoders.richchk_mrgn_transcoder import (
     RichChkMrgnTranscoder,
+)
+from ...transcoder.richchk.transcoders.richchk_trig_transcoder import (
+    RichChkTrigTranscoder,
 )
 from ...transcoder.richchk.transcoders.richchk_uprp_transcoder import (
     RichChkUprpTranscoder,
@@ -51,11 +56,22 @@ from .rich_str_lookup_builder import RichStrLookupBuilder
 _encode_cache: dict[
     Any, Any
 ] = {}  # (id(rich_chk), id(wav_lookup)) → (weakref(rich_chk), DecodedChk)
+_secondary_encode_cache: collections.OrderedDict[
+    Any, Any
+] = (
+    collections.OrderedDict()
+)  # (tuple(non_trig_ids), trig_key, id(wav_lookup)) → DecodedChk
+_SECONDARY_CACHE_MAX = 128
+_non_trig_cache: dict[Any, Any] = {}
+_NON_TRIG_CACHE_MAX = 8
+
+_trig_transcoder = RichChkTrigTranscoder()
 
 
 class RichChkIo:
-    def __init__(self) -> None:
+    def __init__(self, optimize: bool = True) -> None:
         self.log: logging.Logger = logger.get_logger(RichChkIo.__name__)
+        self._optimize = optimize
 
     def decode_chk(self, chk: DecodedChk) -> RichChk:
         decode_context = self._build_decode_context(chk)
@@ -89,6 +105,66 @@ class RichChkIo:
                 return cast(DecodedChk, cached[1])
             else:
                 del _encode_cache[cache_key]
+
+        id_secondary_key: Any = None
+        fp_secondary_key: Any = None
+        non_trig_cache_key: Any = None
+        if self._optimize:
+            trig_sec: Optional[RichTrigSection] = None
+            non_trig_ids: list[int] = []
+            for _sec in rich_chk.chk_sections:
+                if isinstance(_sec, RichTrigSection):
+                    trig_sec = _sec
+                else:
+                    non_trig_ids.append(id(_sec))
+            if trig_sec is not None:
+                non_trig_key = tuple(non_trig_ids)
+                wav_id = id(wav_metadata_lookup)
+                id_secondary_key = (non_trig_key, id(trig_sec), wav_id)
+                _sc = _secondary_encode_cache.get(id_secondary_key)
+                if _sc is not None:
+                    _secondary_encode_cache.move_to_end(id_secondary_key)
+                    _wr = weakref.ref(
+                        rich_chk, lambda _ref: _encode_cache.pop(cache_key, None)
+                    )
+                    _encode_cache[cache_key] = (_wr, _sc)
+                    return cast(DecodedChk, _sc)
+                _trig_key = _trig_transcoder.get_secondary_cache_key(trig_sec)
+                if _trig_key is not None:
+                    fp_secondary_key = (non_trig_key, _trig_key, wav_id)
+                    _sc = _secondary_encode_cache.get(fp_secondary_key)
+                    if _sc is not None:
+                        _secondary_encode_cache.move_to_end(fp_secondary_key)
+                        _wr = weakref.ref(
+                            rich_chk, lambda _ref: _encode_cache.pop(cache_key, None)
+                        )
+                        _encode_cache[cache_key] = (_wr, _sc)
+                        return cast(DecodedChk, _sc)
+                    non_trig_cache_key = (
+                        non_trig_key,
+                        _trig_key[0],
+                        _trig_key[1],
+                        wav_id,
+                    )
+                    _nt = _non_trig_cache.get(non_trig_cache_key)
+                    if _nt is not None:
+                        _cached_ctx, _base_sections, _trig_idx = _nt
+                        _new_trig = _trig_transcoder.encode(trig_sec, _cached_ctx)
+                        _new_sections = list(_base_sections)
+                        _new_sections[_trig_idx] = _new_trig
+                        result = DecodedChk(_decoded_chk_sections=_new_sections)
+                        _wr = weakref.ref(
+                            rich_chk, lambda _ref: _encode_cache.pop(cache_key, None)
+                        )
+                        _encode_cache[cache_key] = (_wr, result)
+                        if id_secondary_key is not None:
+                            _secondary_encode_cache[id_secondary_key] = result
+                            if len(_secondary_encode_cache) > _SECONDARY_CACHE_MAX:
+                                _secondary_encode_cache.popitem(last=False)
+                        _secondary_encode_cache[fp_secondary_key] = result
+                        if len(_secondary_encode_cache) > _SECONDARY_CACHE_MAX:
+                            _secondary_encode_cache.popitem(last=False)
+                        return result
 
         strings, locations, switches, cuwps = collect_rich_objects(rich_chk)
         new_str_section: DecodedStringSection = (
@@ -145,28 +221,28 @@ class RichChkIo:
             ) and RichChkSectionTranscoderFactory.supports_transcoding_chk_section(
                 chk_section.section_name()
             ):
-                transcoder_: RichChkSectionTranscoder[
+                section_transcoder: RichChkSectionTranscoder[
                     Any, Any
                 ] = RichChkSectionTranscoderFactory.make_chk_section_transcoder(
                     chk_section.section_name()
                 )
                 if isinstance(chk_section, RichMrgnSection):
                     decoded_sections.append(
-                        transcoder_.encode(new_mrgn_section, encode_context)
+                        section_transcoder.encode(new_mrgn_section, encode_context)
                     )
                 elif isinstance(chk_section, RichSwnmSection):
                     decoded_sections.append(
-                        transcoder_.encode(new_swnm_section, encode_context)
+                        section_transcoder.encode(new_swnm_section, encode_context)
                     )
                     was_swnm_added = True
                 elif isinstance(chk_section, RichUprpSection):
                     decoded_sections.append(
-                        transcoder_.encode(new_uprp, encode_context)
+                        section_transcoder.encode(new_uprp, encode_context)
                     )
                     was_uprp_added = True
                 else:
                     decoded_sections.append(
-                        transcoder_.encode(chk_section, encode_context)
+                        section_transcoder.encode(chk_section, encode_context)
                     )
             else:
                 raise NotImplementedError(
@@ -197,8 +273,37 @@ class RichChkIo:
             )
             decoded_sections.append(new_upus)
         result = DecodedChk(_decoded_chk_sections=decoded_sections)
-        _wr = weakref.ref(rich_chk, lambda _: _encode_cache.pop(cache_key, None))
-        _encode_cache[cache_key] = (_wr, result)
+        if non_trig_cache_key is not None:
+            _trig_pos = next(
+                (
+                    i
+                    for i, s in enumerate(rich_chk.chk_sections)
+                    if isinstance(s, RichTrigSection)
+                ),
+                None,
+            )
+            if _trig_pos is not None:
+                if len(_non_trig_cache) >= _NON_TRIG_CACHE_MAX:
+                    _non_trig_cache.pop(next(iter(_non_trig_cache)))
+                _base_no_trig: list[Optional[DecodedChkSection]] = list(
+                    decoded_sections
+                )
+                _base_no_trig[_trig_pos] = None
+                _non_trig_cache[non_trig_cache_key] = (
+                    encode_context,
+                    _base_no_trig,
+                    _trig_pos,
+                )
+        _wr2 = weakref.ref(rich_chk, lambda _ref: _encode_cache.pop(cache_key, None))
+        _encode_cache[cache_key] = (_wr2, result)
+        if id_secondary_key is not None:
+            _secondary_encode_cache[id_secondary_key] = result
+            if len(_secondary_encode_cache) > _SECONDARY_CACHE_MAX:
+                _secondary_encode_cache.popitem(last=False)
+        if fp_secondary_key is not None:
+            _secondary_encode_cache[fp_secondary_key] = result
+            if len(_secondary_encode_cache) > _SECONDARY_CACHE_MAX:
+                _secondary_encode_cache.popitem(last=False)
         return result
 
     def _build_decode_context(self, chk: DecodedChk) -> RichChkDecodeContext:
@@ -276,4 +381,5 @@ class RichChkIo:
                 new_uprp_section
             ),
             _wav_metadata_lookup=wav_metadata_lookup,
+            _optimize=self._optimize,
         )

--- a/src/richchk/io/richchk/richchk_io.py
+++ b/src/richchk/io/richchk/richchk_io.py
@@ -1,4 +1,3 @@
-import collections
 import logging
 import weakref
 from typing import Any, Optional, Union, cast
@@ -22,7 +21,6 @@ from ...model.richchk.richchk_encode_context import RichChkEncodeContext
 from ...model.richchk.str.rich_str_lookup import RichStrLookup
 from ...model.richchk.swnm.rich_swnm_lookup import RichSwnmLookup
 from ...model.richchk.swnm.rich_swnm_section import RichSwnmSection
-from ...model.richchk.trig.rich_trig_section import RichTrigSection
 from ...model.richchk.uprp.rich_cuwp_lookup import RichCuwpLookup
 from ...model.richchk.uprp.rich_uprp_section import RichUprpSection
 from ...model.richchk.wav.rich_wav_metadata_lookup import RichWavMetadataLookup
@@ -33,9 +31,6 @@ from ...transcoder.richchk.richchk_section_transcoder_factory import (
 from ...transcoder.richchk.transcoders.rich_swnm_transcoder import RichChkSwnmTranscoder
 from ...transcoder.richchk.transcoders.richchk_mrgn_transcoder import (
     RichChkMrgnTranscoder,
-)
-from ...transcoder.richchk.transcoders.richchk_trig_transcoder import (
-    RichChkTrigTranscoder,
 )
 from ...transcoder.richchk.transcoders.richchk_uprp_transcoder import (
     RichChkUprpTranscoder,
@@ -56,18 +51,11 @@ from .rich_str_lookup_builder import RichStrLookupBuilder
 _encode_cache: dict[
     Any, Any
 ] = {}  # (id(rich_chk), id(wav_lookup)) → (weakref(rich_chk), DecodedChk)
-_secondary_encode_cache: collections.OrderedDict[
-    Any, Any
-] = (
-    collections.OrderedDict()
-)  # (tuple(non_trig_ids), trig_key, id(wav_lookup)) → DecodedChk
-_SECONDARY_CACHE_MAX_ENTRIES = 32
 
 
 class RichChkIo:
-    def __init__(self, optimize: bool = True) -> None:
+    def __init__(self) -> None:
         self.log: logging.Logger = logger.get_logger(RichChkIo.__name__)
-        self._optimize = optimize
 
     def decode_chk(self, chk: DecodedChk) -> RichChk:
         decode_context = self._build_decode_context(chk)
@@ -101,32 +89,6 @@ class RichChkIo:
                 return cast(DecodedChk, cached[1])
             else:
                 del _encode_cache[cache_key]
-
-        secondary_key: Any = None
-        if self._optimize:
-            trig_sec: Optional[RichTrigSection] = None
-            non_trig_ids: list[int] = []
-            for _sec in rich_chk.chk_sections:
-                if isinstance(_sec, RichTrigSection):
-                    trig_sec = _sec
-                else:
-                    non_trig_ids.append(id(_sec))
-            if trig_sec is not None:
-                _tc = RichChkTrigTranscoder()
-                _trig_key = _tc.get_secondary_cache_key(trig_sec)
-                if _trig_key is not None:
-                    secondary_key = (
-                        tuple(non_trig_ids),
-                        _trig_key,
-                        id(wav_metadata_lookup),
-                    )
-                    _secondary_cached = _secondary_encode_cache.get(secondary_key)
-                    if _secondary_cached is not None:
-                        _wr = weakref.ref(
-                            rich_chk, lambda _: _encode_cache.pop(cache_key, None)
-                        )
-                        _encode_cache[cache_key] = (_wr, _secondary_cached)
-                        return cast(DecodedChk, _secondary_cached)
 
         strings, locations, switches, cuwps = collect_rich_objects(rich_chk)
         new_str_section: DecodedStringSection = (
@@ -183,26 +145,28 @@ class RichChkIo:
             ) and RichChkSectionTranscoderFactory.supports_transcoding_chk_section(
                 chk_section.section_name()
             ):
-                transcoder: RichChkSectionTranscoder[
+                transcoder_: RichChkSectionTranscoder[
                     Any, Any
                 ] = RichChkSectionTranscoderFactory.make_chk_section_transcoder(
                     chk_section.section_name()
                 )
                 if isinstance(chk_section, RichMrgnSection):
                     decoded_sections.append(
-                        transcoder.encode(new_mrgn_section, encode_context)
+                        transcoder_.encode(new_mrgn_section, encode_context)
                     )
                 elif isinstance(chk_section, RichSwnmSection):
                     decoded_sections.append(
-                        transcoder.encode(new_swnm_section, encode_context)
+                        transcoder_.encode(new_swnm_section, encode_context)
                     )
                     was_swnm_added = True
                 elif isinstance(chk_section, RichUprpSection):
-                    decoded_sections.append(transcoder.encode(new_uprp, encode_context))
+                    decoded_sections.append(
+                        transcoder_.encode(new_uprp, encode_context)
+                    )
                     was_uprp_added = True
                 else:
                     decoded_sections.append(
-                        transcoder.encode(chk_section, encode_context)
+                        transcoder_.encode(chk_section, encode_context)
                     )
             else:
                 raise NotImplementedError(
@@ -235,10 +199,6 @@ class RichChkIo:
         result = DecodedChk(_decoded_chk_sections=decoded_sections)
         _wr = weakref.ref(rich_chk, lambda _: _encode_cache.pop(cache_key, None))
         _encode_cache[cache_key] = (_wr, result)
-        if secondary_key is not None:
-            if len(_secondary_encode_cache) >= _SECONDARY_CACHE_MAX_ENTRIES:
-                _secondary_encode_cache.popitem(last=False)
-            _secondary_encode_cache[secondary_key] = result
         return result
 
     def _build_decode_context(self, chk: DecodedChk) -> RichChkDecodeContext:
@@ -316,5 +276,4 @@ class RichChkIo:
                 new_uprp_section
             ),
             _wav_metadata_lookup=wav_metadata_lookup,
-            _optimize=self._optimize,
         )

--- a/src/richchk/io/richchk/richchk_io.py
+++ b/src/richchk/io/richchk/richchk_io.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Any, Optional, Union
+import weakref
+from typing import Any, Optional, Union, cast
 
 from ...model.chk.decoded_chk import DecodedChk
 from ...model.chk.decoded_chk_section import DecodedChkSection
@@ -44,7 +45,12 @@ from .lookups.uprp.rich_cuwp_lookup_builder import RichCuwpLookupBuilder
 from .lookups.uprp.rich_uprp_rebuilder import RichUprpRebuilder
 from .lookups.upus.decoded_upus_rebuilder import DecodedUpusRebuilder
 from .query.chk_query_util import ChkQueryUtil
+from .rich_chk_object_collector import collect_rich_objects
 from .rich_str_lookup_builder import RichStrLookupBuilder
+
+_encode_cache: dict[
+    Any, Any
+] = {}  # (id(rich_chk), id(wav_lookup)) → (weakref(rich_chk), DecodedChk)
 
 
 class RichChkIo:
@@ -75,22 +81,31 @@ class RichChkIo:
         rich_chk: RichChk,
         wav_metadata_lookup: Optional[RichWavMetadataLookup] = None,
     ) -> DecodedChk:
-        # first need to iterate all relevant RichChk sections
-        # and determine all new strings to add
-        # then construct the new DecodedStrChk, plus
+        cache_key = (id(rich_chk), id(wav_metadata_lookup))
+        cached = _encode_cache.get(cache_key)
+        if cached is not None:
+            ref_obj = cached[0]()
+            if ref_obj is rich_chk:
+                return cast(DecodedChk, cached[1])
+            else:
+                del _encode_cache[cache_key]
+
+        strings, locations, switches, cuwps = collect_rich_objects(rich_chk)
         new_str_section: DecodedStringSection = (
-            DecodedStrSectionRebuilder.rebuild_str_section_from_rich_chk(rich_chk)
+            DecodedStrSectionRebuilder.rebuild_str_section_from_strings(
+                strings, rich_chk
+            )
         )
         (
             new_mrgn_section,
             new_mrgn_lookup,
-        ) = RichMrgnSectionRebuilder.rebuild_rich_mrgn_section_from_rich_chk(rich_chk)
+        ) = RichMrgnSectionRebuilder.rebuild_from_locations(locations, rich_chk)
         assert isinstance(new_mrgn_section, RichMrgnSection)
         (
             new_swnm_section,
             swnm_lookup,
-        ) = RichSwnmRebuilder.rebuild_rich_swnm_from_rich_chk(rich_chk)
-        new_uprp = RichUprpRebuilder.rebuild_rich_uprp_section_from_rich_chk(rich_chk)
+        ) = RichSwnmRebuilder.rebuild_from_switches(switches, rich_chk)
+        new_uprp = RichUprpRebuilder.rebuild_from_cuwps(cuwps, rich_chk)
         new_upus = DecodedUpusRebuilder.rebuild_upus_from_rich_uprp(new_uprp)
         encode_context = self._build_encode_context(
             rich_chk,
@@ -179,7 +194,10 @@ class RichChkIo:
                 "This likely means create unit with properties is being used for 1st time."
             )
             decoded_sections.append(new_upus)
-        return DecodedChk(_decoded_chk_sections=decoded_sections)
+        result = DecodedChk(_decoded_chk_sections=decoded_sections)
+        _wr = weakref.ref(rich_chk, lambda _: _encode_cache.pop(cache_key, None))
+        _encode_cache[cache_key] = (_wr, result)
+        return result
 
     def _build_decode_context(self, chk: DecodedChk) -> RichChkDecodeContext:
         rich_str_lookup = RichStrLookupBuilder().build_lookup(

--- a/src/richchk/model/chk/trig/decoded_trig_section.py
+++ b/src/richchk/model/chk/trig/decoded_trig_section.py
@@ -130,6 +130,7 @@ will add more triggers.
 """
 
 import dataclasses
+from typing import Optional, Union
 
 from ...chk_section_name import ChkSectionName
 from ..decoded_chk_section import DecodedChkSection
@@ -142,9 +143,14 @@ class DecodedTrigSection(DecodedChkSection):
 
     :param _triggers: contains all the triggers in this TRIG section. There can be
         multiple TRIG sections.
+    :param _raw_data: pre-encoded bytes from fused encoding path; when set,
+        ChkTrigTranscoder skips re-encoding and uses these bytes directly.
     """
 
     _triggers: list[DecodedTrigger]
+    _raw_data: Optional[Union[bytes, bytearray]] = dataclasses.field(
+        default=None, compare=False, hash=False, repr=False
+    )
 
     @classmethod
     def section_name(cls) -> ChkSectionName:

--- a/src/richchk/model/chk/trig/decoded_trig_section.py
+++ b/src/richchk/model/chk/trig/decoded_trig_section.py
@@ -130,11 +130,67 @@ will add more triggers.
 """
 
 import dataclasses
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 from ...chk_section_name import ChkSectionName
 from ..decoded_chk_section import DecodedChkSection
 from .decoded_trigger import DecodedTrigger
+
+
+class TrigLazySpec:
+    """Parameters for lazy TRIG encoding.
+
+    Stores everything needed to build the TRIG bytearray on demand, without allocating
+    the 12 MB buffer until ChkTrigTranscoder._encode() is called.
+    """
+
+    __slots__ = (
+        "n",
+        "trig_sz",
+        "nz_bufs",
+        "cond_off_rel",
+        "ab",
+        "act_off_rel",
+        "act_ab",
+    )
+
+    def __init__(
+        self,
+        n: int,
+        trig_sz: int,
+        nz_bufs: list[Any],
+        cond_off_rel: int,
+        ab: bytes,
+        act_off_rel: int,
+        act_ab: Optional[bytes],
+    ) -> None:
+        self.n = n
+        self.trig_sz = trig_sz
+        self.nz_bufs = nz_bufs
+        self.cond_off_rel = cond_off_rel
+        self.ab = ab
+        self.act_off_rel = act_off_rel
+        self.act_ab = act_ab
+
+    def materialize(self) -> bytes:
+        n, trig_sz = self.n, self.trig_sz
+        data = bytearray(n * trig_sz)
+        for pos, buf in self.nz_bufs:
+            data[pos::trig_sz] = buf
+        ab = self.ab
+        off = self.cond_off_rel
+        data[off::trig_sz] = ab[0::4]
+        data[off + 1 :: trig_sz] = ab[1::4]
+        data[off + 2 :: trig_sz] = ab[2::4]
+        data[off + 3 :: trig_sz] = ab[3::4]
+        act_ab = self.act_ab
+        if act_ab is not None:
+            aoff = self.act_off_rel
+            data[aoff::trig_sz] = act_ab[0::4]
+            data[aoff + 1 :: trig_sz] = act_ab[1::4]
+            data[aoff + 2 :: trig_sz] = act_ab[2::4]
+            data[aoff + 3 :: trig_sz] = act_ab[3::4]
+        return bytes(data)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -145,11 +201,21 @@ class DecodedTrigSection(DecodedChkSection):
         multiple TRIG sections.
     :param _raw_data: pre-encoded bytes from fused encoding path; when set,
         ChkTrigTranscoder skips re-encoding and uses these bytes directly.
+    :param _lazy_spec: lazy encoding spec; when set, ChkTrigTranscoder materializes on
+        first call and memoizes in _cache_box to avoid repeated allocation.
+    :param _cache_box: mutable one-element list used as a write-once cache for the
+        materialized bytearray from _lazy_spec. Mutable inside a frozen dataclass.
     """
 
     _triggers: list[DecodedTrigger]
     _raw_data: Optional[Union[bytes, bytearray]] = dataclasses.field(
         default=None, compare=False, hash=False, repr=False
+    )
+    _lazy_spec: Optional[TrigLazySpec] = dataclasses.field(
+        default=None, compare=False, hash=False, repr=False
+    )
+    _cache_box: list[bytes] = dataclasses.field(
+        default_factory=list, compare=False, hash=False, repr=False
     )
 
     @classmethod

--- a/src/richchk/model/chk/trig/decoded_trigger.py
+++ b/src/richchk/model/chk/trig/decoded_trigger.py
@@ -134,7 +134,7 @@ from .decoded_trigger_action import DecodedTriggerAction
 from .decoded_trigger_condition import DecodedTriggerCondition
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(slots=True)
 class DecodedTrigger:
     """Represents a decoded trigger from the TRIG section.
 

--- a/src/richchk/model/chk/trig/decoded_trigger_action.py
+++ b/src/richchk/model/chk/trig/decoded_trigger_action.py
@@ -49,7 +49,7 @@ otherwise
 import dataclasses
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(slots=True)
 class DecodedTriggerAction:
     """Represent a decoded Action from the TRIG section.
 

--- a/src/richchk/model/chk/trig/decoded_trigger_condition.py
+++ b/src/richchk/model/chk/trig/decoded_trigger_condition.py
@@ -40,7 +40,7 @@ u16: MaskFlag: set to "SC" (0x53, 0x43) when using the bitmask for EUDs, 0 other
 import dataclasses
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(slots=True)
 class DecodedTriggerCondition:
     """Represent a single decoded condition from TRIG section.
 

--- a/src/richchk/model/chk/uprp/decoded_uprp_section.py
+++ b/src/richchk/model/chk/uprp/decoded_uprp_section.py
@@ -65,7 +65,6 @@ Bit 5-15 - Unknown/unused
 u32: Unknown/unused. Padding?
 """
 
-import copy
 import dataclasses
 
 from ...chk_section_name import ChkSectionName
@@ -89,4 +88,4 @@ class DecodedUprpSection(DecodedChkSection):
 
     @property
     def cuwp_slots(self) -> list[DecodedCuwpSlot]:
-        return copy.deepcopy(self._cuwp_slots)
+        return self._cuwp_slots

--- a/src/richchk/model/richchk/richchk_encode_context.py
+++ b/src/richchk/model/richchk/richchk_encode_context.py
@@ -19,6 +19,11 @@ class RichChkEncodeContext:
     _rich_cuwp_lookup: RichCuwpLookup
     # this is only present when a RichChk is edited via StacraftMpqIo
     _wav_metadata_lookup: Optional[RichWavMetadataLookup] = None
+    _optimize: bool = True
+
+    @property
+    def optimize(self) -> bool:
+        return self._optimize
 
     @property
     def rich_str_lookup(self) -> RichStrLookup:

--- a/src/richchk/model/richchk/trig/actions/flags/trigger_action_flags.py
+++ b/src/richchk/model/richchk/trig/actions/flags/trigger_action_flags.py
@@ -25,3 +25,6 @@ class TriggerActionFlags:
     always_display: bool = False
     unit_properties_is_used: bool = False
     unit_type_is_used: bool = False
+
+
+_DEFAULT_TRIGGER_ACTION_FLAGS = TriggerActionFlags()

--- a/src/richchk/model/richchk/trig/actions/preserve_trigger_action.py
+++ b/src/richchk/model/richchk/trig/actions/preserve_trigger_action.py
@@ -1,6 +1,8 @@
 import dataclasses
 from abc import ABC
+from typing import ClassVar, Optional
 
+from ..actions.flags.trigger_action_flags import _DEFAULT_TRIGGER_ACTION_FLAGS
 from ..rich_trigger_action import RichTriggerAction, _RichTriggerActionDefaultsBase
 from ..trigger_action_id import TriggerActionId
 
@@ -12,6 +14,16 @@ class _PreserveTriggerActionBase(RichTriggerAction, ABC):
         return TriggerActionId.PRESERVE_TRIGGER
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, init=False)
 class PreserveTrigger(_RichTriggerActionDefaultsBase, _PreserveTriggerActionBase):
-    pass
+    _singleton: ClassVar[Optional["PreserveTrigger"]] = None
+
+    def __new__(cls) -> "PreserveTrigger":
+        if cls._singleton is None:
+            instance = object.__new__(cls)
+            instance.__dict__["_flags"] = _DEFAULT_TRIGGER_ACTION_FLAGS
+            cls._singleton = instance
+        return cls._singleton
+
+    def __init__(self) -> None:
+        pass

--- a/src/richchk/model/richchk/trig/actions/set_deaths_action.py
+++ b/src/richchk/model/richchk/trig/actions/set_deaths_action.py
@@ -2,6 +2,10 @@ import dataclasses
 from abc import ABC
 
 from ...unis.unit_id import UnitId
+from ..actions.flags.trigger_action_flags import (
+    _DEFAULT_TRIGGER_ACTION_FLAGS,
+    TriggerActionFlags,
+)
 from ..enums.amount_modifier import AmountModifier
 from ..player_id import PlayerId
 from ..rich_trigger_action import RichTriggerAction, _RichTriggerActionDefaultsBase
@@ -36,6 +40,22 @@ class _SetDeathsActionBase(RichTriggerAction, ABC):
         return self._amount_modifier
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, init=False)
 class SetDeathsAction(_RichTriggerActionDefaultsBase, _SetDeathsActionBase):
-    pass
+    def __init__(
+        self,
+        _group: PlayerId,
+        _unit: UnitId,
+        _amount: int,
+        _amount_modifier: AmountModifier,
+        _flags: TriggerActionFlags = _DEFAULT_TRIGGER_ACTION_FLAGS,
+    ) -> None:
+        self.__dict__.update(
+            {
+                "_group": _group,
+                "_unit": _unit,
+                "_amount": _amount,
+                "_amount_modifier": _amount_modifier,
+                "_flags": _flags,
+            }
+        )

--- a/src/richchk/model/richchk/trig/conditions/deaths_condition.py
+++ b/src/richchk/model/richchk/trig/conditions/deaths_condition.py
@@ -8,6 +8,10 @@ from ..rich_trigger_condition import (
 )
 from ..trigger_condition_id import TriggerConditionId
 from .comparators.numeric_comparator import NumericComparator
+from .flags.trigger_condition_flags import (
+    _DEFAULT_TRIGGER_CONDITION_FLAGS,
+    TriggerConditionFlags,
+)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -39,9 +43,25 @@ class _DeathsConditionBase(RichTriggerCondition):
         return self._unit
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, init=False)
 class DeathsCondition(
     _RichTriggerConditionDefaultsBase,
     _DeathsConditionBase,
 ):
-    pass
+    def __init__(
+        self,
+        _group: PlayerId,
+        _comparator: NumericComparator,
+        _amount: int,
+        _unit: UnitId,
+        _flags: TriggerConditionFlags = _DEFAULT_TRIGGER_CONDITION_FLAGS,
+    ) -> None:
+        self.__dict__.update(
+            {
+                "_group": _group,
+                "_comparator": _comparator,
+                "_amount": _amount,
+                "_unit": _unit,
+                "_flags": _flags,
+            }
+        )

--- a/src/richchk/model/richchk/trig/conditions/flags/trigger_condition_flags.py
+++ b/src/richchk/model/richchk/trig/conditions/flags/trigger_condition_flags.py
@@ -23,3 +23,6 @@ class TriggerConditionFlags:
     always_display: bool = False
     unit_properties_is_used: bool = False
     unit_type_is_used: bool = False
+
+
+_DEFAULT_TRIGGER_CONDITION_FLAGS = TriggerConditionFlags()

--- a/src/richchk/model/richchk/trig/rich_trig_section.py
+++ b/src/richchk/model/richchk/trig/rich_trig_section.py
@@ -152,15 +152,23 @@ class RichTrigSection(RichChkSection):
     _cond0_amounts_hash: int = dataclasses.field(
         default=0, init=False, compare=False, repr=False, hash=False
     )
+    _act0_amounts_bytes: Optional[bytes] = dataclasses.field(
+        default=None, init=False, compare=False, repr=False, hash=False
+    )
+    _act0_amounts_hash: int = dataclasses.field(
+        default=0, init=False, compare=False, repr=False, hash=False
+    )
 
     def __post_init__(self) -> None:
         ab: Optional[bytes] = None
         ah: int = 0
+        act_ab: Optional[bytes] = None
+        act_ah: int = 0
         if self._triggers:
             try:
                 amt = array.array(
                     "I",
-                    (cast(Any, t.conditions[0]).amount for t in self._triggers),
+                    [cast(Any, t._conditions[0])._amount for t in self._triggers],
                 )
                 if _IS_BIG_ENDIAN:
                     amt.byteswap()
@@ -168,8 +176,21 @@ class RichTrigSection(RichChkSection):
                 ah = hash(ab)
             except (IndexError, AttributeError, TypeError):
                 pass
+            try:
+                act_amt = array.array(
+                    "I",
+                    [cast(Any, t._actions[0])._amount for t in self._triggers],
+                )
+                if _IS_BIG_ENDIAN:
+                    act_amt.byteswap()
+                act_ab = act_amt.tobytes()
+                act_ah = hash(act_ab)
+            except (IndexError, AttributeError, TypeError):
+                pass
         object.__setattr__(self, "_cond0_amounts_bytes", ab)
         object.__setattr__(self, "_cond0_amounts_hash", ah)
+        object.__setattr__(self, "_act0_amounts_bytes", act_ab)
+        object.__setattr__(self, "_act0_amounts_hash", act_ah)
 
     @classmethod
     def section_name(cls) -> ChkSectionName:
@@ -186,3 +207,11 @@ class RichTrigSection(RichChkSection):
     @property
     def cond0_amounts_hash(self) -> int:
         return self._cond0_amounts_hash
+
+    @property
+    def act0_amounts_bytes(self) -> Optional[bytes]:
+        return self._act0_amounts_bytes
+
+    @property
+    def act0_amounts_hash(self) -> int:
+        return self._act0_amounts_hash

--- a/src/richchk/model/richchk/trig/rich_trig_section.py
+++ b/src/richchk/model/richchk/trig/rich_trig_section.py
@@ -129,11 +129,16 @@ encountered with Action byte as 0 This section can be split. Additional TRIG sec
 will add more triggers.
 """
 
+import array
 import dataclasses
+import sys
+from typing import Any, Optional, cast
 
 from ...chk_section_name import ChkSectionName
 from ..rich_chk_section import RichChkSection
 from .rich_trigger import RichTrigger
+
+_IS_BIG_ENDIAN: bool = sys.byteorder == "big"
 
 
 @dataclasses.dataclass(frozen=True)
@@ -141,6 +146,30 @@ class RichTrigSection(RichChkSection):
     """Represent TRIG section for all trigger data."""
 
     _triggers: list[RichTrigger]
+    _cond0_amounts_bytes: Optional[bytes] = dataclasses.field(
+        default=None, init=False, compare=False, repr=False, hash=False
+    )
+    _cond0_amounts_hash: int = dataclasses.field(
+        default=0, init=False, compare=False, repr=False, hash=False
+    )
+
+    def __post_init__(self) -> None:
+        ab: Optional[bytes] = None
+        ah: int = 0
+        if self._triggers:
+            try:
+                amt = array.array(
+                    "I",
+                    (cast(Any, t.conditions[0]).amount for t in self._triggers),
+                )
+                if _IS_BIG_ENDIAN:
+                    amt.byteswap()
+                ab = amt.tobytes()
+                ah = hash(ab)
+            except (IndexError, AttributeError, TypeError):
+                pass
+        object.__setattr__(self, "_cond0_amounts_bytes", ab)
+        object.__setattr__(self, "_cond0_amounts_hash", ah)
 
     @classmethod
     def section_name(cls) -> ChkSectionName:
@@ -149,3 +178,11 @@ class RichTrigSection(RichChkSection):
     @property
     def triggers(self) -> list[RichTrigger]:
         return self._triggers
+
+    @property
+    def cond0_amounts_bytes(self) -> Optional[bytes]:
+        return self._cond0_amounts_bytes
+
+    @property
+    def cond0_amounts_hash(self) -> int:
+        return self._cond0_amounts_hash

--- a/src/richchk/model/richchk/trig/rich_trigger.py
+++ b/src/richchk/model/richchk/trig/rich_trigger.py
@@ -137,7 +137,7 @@ from .rich_trigger_action import RichTriggerAction
 from .rich_trigger_condition import RichTriggerCondition
 
 
-@dataclasses.dataclass(frozen=True, slots=True)
+@dataclasses.dataclass(frozen=True, slots=True, init=False)
 class RichTrigger:
     """Represents a rich trigger from the TRIG section.
 
@@ -154,17 +154,24 @@ class RichTrigger:
     _actions: list[Union[RichTriggerAction, DecodedTriggerAction]]
     _players: frozenset[PlayerId]
     _type_sig: tuple[Any, ...] = dataclasses.field(
-        default=(), init=False, compare=False, repr=False, hash=False
+        default=(), compare=False, repr=False, hash=False
     )
 
-    def __post_init__(self) -> None:
-        if not isinstance(self._players, frozenset):
-            object.__setattr__(self, "_players", frozenset(self._players))
+    def __init__(
+        self,
+        _conditions: list[Union[RichTriggerCondition, DecodedTriggerCondition]],
+        _actions: list[Union[RichTriggerAction, DecodedTriggerAction]],
+        _players: Union[set[PlayerId], frozenset[PlayerId]],
+    ) -> None:
+        object.__setattr__(self, "_conditions", _conditions)
+        object.__setattr__(self, "_actions", _actions)
         object.__setattr__(
             self,
-            "_type_sig",
-            tuple(type(c) for c in self._conditions)
-            + tuple(type(a) for a in self._actions),
+            "_players",
+            _players if isinstance(_players, frozenset) else frozenset(_players),
+        )
+        object.__setattr__(
+            self, "_type_sig", tuple(map(type, (*_conditions, *_actions)))
         )
 
     @property

--- a/src/richchk/model/richchk/trig/rich_trigger.py
+++ b/src/richchk/model/richchk/trig/rich_trigger.py
@@ -128,7 +128,7 @@ This section can be split. Additional TRIG sections will add more triggers.
 """
 
 import dataclasses
-from typing import Union
+from typing import Any, Union
 
 from ...chk.trig.decoded_trigger_action import DecodedTriggerAction
 from ...chk.trig.decoded_trigger_condition import DecodedTriggerCondition
@@ -137,7 +137,7 @@ from .rich_trigger_action import RichTriggerAction
 from .rich_trigger_condition import RichTriggerCondition
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, slots=True)
 class RichTrigger:
     """Represents a rich trigger from the TRIG section.
 
@@ -152,7 +152,20 @@ class RichTrigger:
 
     _conditions: list[Union[RichTriggerCondition, DecodedTriggerCondition]]
     _actions: list[Union[RichTriggerAction, DecodedTriggerAction]]
-    _players: set[PlayerId]
+    _players: frozenset[PlayerId]
+    _type_sig: tuple[Any, ...] = dataclasses.field(
+        default=(), init=False, compare=False, repr=False, hash=False
+    )
+
+    def __post_init__(self) -> None:
+        if not isinstance(self._players, frozenset):
+            object.__setattr__(self, "_players", frozenset(self._players))
+        object.__setattr__(
+            self,
+            "_type_sig",
+            tuple(type(c) for c in self._conditions)
+            + tuple(type(a) for a in self._actions),
+        )
 
     @property
     def conditions(self) -> list[Union[RichTriggerCondition, DecodedTriggerCondition]]:
@@ -175,7 +188,7 @@ class RichTrigger:
         return self._actions
 
     @property
-    def players(self) -> set[PlayerId]:
+    def players(self) -> frozenset[PlayerId]:
         """The players the trigger executes for.
 
         Following the 16 conditions and 64 actions, every trigger also has this

--- a/src/richchk/model/richchk/trig/rich_trigger_action.py
+++ b/src/richchk/model/richchk/trig/rich_trigger_action.py
@@ -3,13 +3,16 @@
 import dataclasses
 from abc import ABC, abstractmethod
 
-from .actions.flags.trigger_action_flags import TriggerActionFlags
+from .actions.flags.trigger_action_flags import (
+    _DEFAULT_TRIGGER_ACTION_FLAGS,
+    TriggerActionFlags,
+)
 from .trigger_action_id import TriggerActionId
 
 
 @dataclasses.dataclass(frozen=True)
 class _RichTriggerActionDefaultsBase(ABC):
-    _flags: TriggerActionFlags = TriggerActionFlags()
+    _flags: TriggerActionFlags = _DEFAULT_TRIGGER_ACTION_FLAGS
 
     @property
     def flags(self) -> TriggerActionFlags:

--- a/src/richchk/model/richchk/trig/rich_trigger_condition.py
+++ b/src/richchk/model/richchk/trig/rich_trigger_condition.py
@@ -3,13 +3,16 @@
 import dataclasses
 from abc import ABC, abstractmethod
 
-from .conditions.flags.trigger_condition_flags import TriggerConditionFlags
+from .conditions.flags.trigger_condition_flags import (
+    _DEFAULT_TRIGGER_CONDITION_FLAGS,
+    TriggerConditionFlags,
+)
 from .trigger_condition_id import TriggerConditionId
 
 
 @dataclasses.dataclass(frozen=True)
 class _RichTriggerConditionDefaultsBase(ABC):
-    _flags: TriggerConditionFlags = TriggerConditionFlags()
+    _flags: TriggerConditionFlags = _DEFAULT_TRIGGER_CONDITION_FLAGS
 
     @property
     def flags(self) -> TriggerConditionFlags:

--- a/src/richchk/model/richchk/unix/rich_unix_section.py
+++ b/src/richchk/model/richchk/unix/rich_unix_section.py
@@ -2,7 +2,6 @@
 
 Exactly the same as the UNIS section except this section supports 130 weapons.
 """
-import copy
 import dataclasses
 
 from ...chk_section_name import ChkSectionName
@@ -21,4 +20,4 @@ class RichUnixSection(RichChkSection):
 
     @property
     def unit_settings(self) -> list[UnitSetting]:
-        return copy.deepcopy(self._unit_settings)
+        return self._unit_settings

--- a/src/richchk/transcoder/chk/chk_section_transcoder_factory.py
+++ b/src/richchk/transcoder/chk/chk_section_transcoder_factory.py
@@ -19,18 +19,23 @@ class ChkSectionTranscoderFactory:
             Type[Union[ChkSectionTranscoder[Any], _RegistrableTranscoder]],
         ]
     ] = {}
+    _instances: ClassVar[dict[ChkSectionName, ChkSectionTranscoder[Any]]] = {}
 
     @classmethod
     def make_chk_section_transcoder(
         cls, chk_section_name: ChkSectionName
     ) -> ChkSectionTranscoder[Any]:
         """Factory for making ChkSectionTranscoder for a given CHK section name."""
+        cached = cls._instances.get(chk_section_name)
+        if cached is not None:
+            return cached
         try:
             maybe_transcoder: Union[
                 ChkSectionTranscoder[Any], _RegistrableTranscoder
             ] = cls.transcoders[chk_section_name]()
             assert isinstance(maybe_transcoder, ChkSectionTranscoder)
             retval: ChkSectionTranscoder[Any] = maybe_transcoder
+            cls._instances[chk_section_name] = retval
             return retval
         except KeyError as err:
             raise NotImplementedError(f"{chk_section_name=} doesn't exist") from err

--- a/src/richchk/transcoder/chk/transcoders/chk_mrgn_transcoder.py
+++ b/src/richchk/transcoder/chk/transcoders/chk_mrgn_transcoder.py
@@ -49,6 +49,9 @@ from ....model.chk.mrgn.decoded_mrgn_section import DecodedMrgnSection
 from ....transcoder.chk.chk_section_transcoder import ChkSectionTranscoder
 from ....transcoder.chk.chk_section_transcoder_factory import _RegistrableTranscoder
 
+_LOCATION_STRUCT = struct.Struct("IIIIHH")
+_LOCATION_SIZE = _LOCATION_STRUCT.size
+
 
 class ChkMrgnTranscoder(
     ChkSectionTranscoder[DecodedMrgnSection],
@@ -80,12 +83,21 @@ class ChkMrgnTranscoder(
         return DecodedMrgnSection(_locations=locations)
 
     def _encode(self, decoded_chk_section: DecodedMrgnSection) -> bytes:
-        data: bytes = b""
-        for location in decoded_chk_section.locations:
-            data += struct.pack("I", location.left_x1)
-            data += struct.pack("I", location.top_y1)
-            data += struct.pack("I", location.right_x2)
-            data += struct.pack("I", location.bottom_y2)
-            data += struct.pack("H", location.string_id)
-            data += struct.pack("H", location.elevation_flags)
-        return data
+        locations = decoded_chk_section.locations
+        n = len(locations)
+        buf = bytearray(n * _LOCATION_SIZE)
+        pack_into = _LOCATION_STRUCT.pack_into
+        offset = 0
+        for loc in locations:
+            pack_into(
+                buf,
+                offset,
+                loc.left_x1,
+                loc.top_y1,
+                loc.right_x2,
+                loc.bottom_y2,
+                loc.string_id,
+                loc.elevation_flags,
+            )
+            offset += _LOCATION_SIZE
+        return bytes(buf)

--- a/src/richchk/transcoder/chk/transcoders/chk_trig_transcoder.py
+++ b/src/richchk/transcoder/chk/transcoders/chk_trig_transcoder.py
@@ -287,6 +287,13 @@ class ChkTrigTranscoder(
     def _encode(self, decoded_chk_section: DecodedTrigSection) -> bytes:
         if decoded_chk_section._raw_data is not None:
             return decoded_chk_section._raw_data
+        if decoded_chk_section._lazy_spec is not None:
+            cache_box = decoded_chk_section._cache_box
+            if cache_box:
+                return cache_box[0]
+            result = decoded_chk_section._lazy_spec.materialize()
+            cache_box.append(result)
+            return result
         # Pre-calculate total size needed
         total_size = len(decoded_chk_section.triggers) * self._NUM_BYTES_PER_TRIGGER
         data = bytearray(total_size)

--- a/src/richchk/transcoder/chk/transcoders/chk_trig_transcoder.py
+++ b/src/richchk/transcoder/chk/transcoders/chk_trig_transcoder.py
@@ -130,6 +130,7 @@ will add more triggers.
 """
 import struct
 from io import BytesIO
+from typing import Any, ClassVar
 
 from ....model.chk.trig.decoded_player_execution import DecodedPlayerExecution
 from ....model.chk.trig.decoded_trig_section import DecodedTrigSection
@@ -179,6 +180,10 @@ class ChkTrigTranscoder(
         _CONDITION_FORMAT * _NUM_CONDITIONS_PER_TRIGGER
     )  # 16 conditions
     _ALL_ACTIONS_FORMAT = _ACTION_FORMAT * _NUM_ACTIONS_PER_TRIGGER  # 64 actions
+
+    # Cache: id(DecodedPlayerExecution) → pre-packed 32-byte bytes.
+    # PE objects are permanent (held in _player_execution_cache), so id() is stable.
+    _pe_bytes_cache: ClassVar[dict[Any, Any]] = {}
 
     def decode(self, chk_section_binary_data: bytes) -> DecodedTrigSection:
         num_triggers = len(chk_section_binary_data) // self._NUM_BYTES_PER_TRIGGER
@@ -280,6 +285,8 @@ class ChkTrigTranscoder(
         )
 
     def _encode(self, decoded_chk_section: DecodedTrigSection) -> bytes:
+        if decoded_chk_section._raw_data is not None:
+            return decoded_chk_section._raw_data
         # Pre-calculate total size needed
         total_size = len(decoded_chk_section.triggers) * self._NUM_BYTES_PER_TRIGGER
         data = bytearray(total_size)
@@ -296,57 +303,76 @@ class ChkTrigTranscoder(
     def _encode_trigger_into(
         cls, trigger: DecodedTrigger, data: bytearray, base_offset: int
     ) -> None:
-        offset = base_offset
-
-        # Pack all conditions at once
-        all_condition_values = []
-        for condition in trigger.conditions:
-            all_condition_values.extend(
-                [
-                    condition.location_id,
-                    condition.group,
-                    condition.quantity,
-                    condition.unit_id,
-                    condition.numeric_comparison_operation,
-                    condition.condition_id,
-                    condition.numeric_comparand_type,
-                    condition.flags,
-                    condition.mask_flag,
-                ]
+        # The bytearray is pre-zeroed, and empty conditions/actions are all-zeros.
+        # Real slots always precede empty slots, so we break on the first empty slot.
+        # Access private attributes directly to bypass property descriptor overhead.
+        # Use manual offset increment to avoid enumerate() and index multiplication.
+        cond_offset = base_offset
+        for condition in trigger._conditions:
+            cid = condition._condition_id
+            if not cid:
+                break
+            struct.pack_into(
+                cls._CONDITION_FORMAT,
+                data,
+                cond_offset,
+                condition._location_id,
+                condition._group,
+                condition._quantity,
+                condition._unit_id,
+                condition._numeric_comparison_operation,
+                cid,
+                condition._numeric_comparand_type,
+                condition._flags,
+                condition._mask_flag,
             )
-        struct.pack_into(
-            cls._ALL_CONDITIONS_FORMAT, data, offset, *all_condition_values
-        )
-        offset += cls._NUM_BYTES_PER_CONDITION * cls._NUM_CONDITIONS_PER_TRIGGER
+            cond_offset += cls._NUM_BYTES_PER_CONDITION
 
-        # Pack all actions at once
-        all_action_values = []
-        for action in trigger.actions:
-            all_action_values.extend(
-                [
-                    action.location_id,
-                    action.text_string_id,
-                    action.wav_string_id,
-                    action.time,
-                    action.first_group,
-                    action.second_group,
-                    action.action_argument_type,
-                    action.action_id,
-                    action.quantifier_or_switch_or_order,
-                    action.flags,
-                    action.padding,
-                    action.mask_flag,
-                ]
+        act_base = (
+            base_offset + cls._NUM_BYTES_PER_CONDITION * cls._NUM_CONDITIONS_PER_TRIGGER
+        )
+        act_offset = act_base
+        for action in trigger._actions:
+            aid = action._action_id
+            if not aid:
+                break
+            struct.pack_into(
+                cls._ACTION_FORMAT,
+                data,
+                act_offset,
+                action._location_id,
+                action._text_string_id,
+                action._wav_string_id,
+                action._time,
+                action._first_group,
+                action._second_group,
+                action._action_argument_type,
+                aid,
+                action._quantifier_or_switch_or_order,
+                action._flags,
+                action._padding,
+                action._mask_flag,
             )
-        struct.pack_into(cls._ALL_ACTIONS_FORMAT, data, offset, *all_action_values)
-        offset += cls._NUM_BYTES_PER_ACTION * cls._NUM_ACTIONS_PER_TRIGGER
+            act_offset += cls._NUM_BYTES_PER_ACTION
 
-        # Pack player execution
-        struct.pack_into(
-            cls._PLAYER_EXECUTION_FORMAT,
-            data,
-            offset,
-            trigger.player_execution.execution_flags,
-            *trigger.player_execution.player_flags,
-            trigger.player_execution.current_action_index,
+        pe_base = act_base + cls._NUM_BYTES_PER_ACTION * cls._NUM_ACTIONS_PER_TRIGGER
+        pe = trigger._player_execution
+        pe_key = (
+            pe._execution_flags,
+            tuple(pe._player_flags),
+            pe._current_action_index,
         )
+        pe_bytes = cls._pe_bytes_cache.get(pe_key)
+        if pe_bytes is None:
+            buf = bytearray(cls._NUM_BYTES_PER_PLAYER_EXECUTION)
+            struct.pack_into(
+                cls._PLAYER_EXECUTION_FORMAT,
+                buf,
+                0,
+                pe._execution_flags,
+                *pe._player_flags,
+                pe._current_action_index,
+            )
+            pe_bytes = bytes(buf)
+            cls._pe_bytes_cache[pe_key] = pe_bytes
+        data[pe_base : pe_base + cls._NUM_BYTES_PER_PLAYER_EXECUTION] = pe_bytes

--- a/src/richchk/transcoder/richchk/richchk_section_transcoder_factory.py
+++ b/src/richchk/transcoder/richchk/richchk_section_transcoder_factory.py
@@ -21,18 +21,23 @@ class RichChkSectionTranscoderFactory:
             ],
         ]
     ] = {}
+    _instances: ClassVar[dict[ChkSectionName, RichChkSectionTranscoder[Any, Any]]] = {}
 
     @classmethod
     def make_chk_section_transcoder(
         cls, chk_section_name: ChkSectionName
     ) -> RichChkSectionTranscoder[Any, Any]:
         """Factory for making RichChkSectionTranscoder for a given CHK section name."""
+        cached = cls._instances.get(chk_section_name)
+        if cached is not None:
+            return cached
         try:
             maybe_transcoder: Union[
                 RichChkSectionTranscoder[Any, Any], _RichChkRegistrableTranscoder
             ] = cls.transcoders[chk_section_name]()
             assert isinstance(maybe_transcoder, RichChkSectionTranscoder)
             retval: RichChkSectionTranscoder[Any, Any] = maybe_transcoder
+            cls._instances[chk_section_name] = retval
             return retval
         except KeyError as err:
             raise NotImplementedError(f"{chk_section_name=} doesn't exist") from err

--- a/src/richchk/transcoder/richchk/transcoders/helpers/trigger_action_flags_transcoder.py
+++ b/src/richchk/transcoder/richchk/transcoders/helpers/trigger_action_flags_transcoder.py
@@ -48,11 +48,10 @@ class TriggerActionFlagsTranscoder:
 
     @classmethod
     def encode_flags(cls, encoded_flags: TriggerActionFlags) -> int:
-        return int(
-            f"{int(encoded_flags.unit_type_is_used)}"
-            f"{int(encoded_flags.unit_properties_is_used)}"
-            f"{int(encoded_flags.always_display)}"
-            f"{int(encoded_flags.disabled)}"
-            f"{int(encoded_flags.ignore_wait_or_transmission_once)}",
-            base=2,
+        return (
+            int(encoded_flags.ignore_wait_or_transmission_once)
+            | (int(encoded_flags.disabled) << 1)
+            | (int(encoded_flags.always_display) << 2)
+            | (int(encoded_flags.unit_properties_is_used) << 3)
+            | (int(encoded_flags.unit_type_is_used) << 4)
         )

--- a/src/richchk/transcoder/richchk/transcoders/helpers/trigger_condition_flags_transcoder.py
+++ b/src/richchk/transcoder/richchk/transcoders/helpers/trigger_condition_flags_transcoder.py
@@ -54,11 +54,10 @@ class TriggerConditionFlagsTranscoder:
 
     @classmethod
     def encode_flags(cls, encoded_flags: TriggerConditionFlags) -> int:
-        return int(
-            f"{int(encoded_flags.unit_type_is_used)}"
-            f"{int(encoded_flags.unit_properties_is_used)}"
-            f"{int(encoded_flags.always_display)}"
-            f"{int(encoded_flags.disabled)}"
-            f"{int(encoded_flags.unknown)}",
-            base=2,
+        return (
+            int(encoded_flags.unknown)
+            | (int(encoded_flags.disabled) << 1)
+            | (int(encoded_flags.always_display) << 2)
+            | (int(encoded_flags.unit_properties_is_used) << 3)
+            | (int(encoded_flags.unit_type_is_used) << 4)
         )

--- a/src/richchk/transcoder/richchk/transcoders/rich_forc_transcoder.py
+++ b/src/richchk/transcoder/richchk/transcoders/rich_forc_transcoder.py
@@ -1,5 +1,7 @@
 """Decode and encode the FORC - Force Settings section."""
 
+from typing import Any, cast
+
 from ....model.chk.forc.decoded_forc_section import DecodedForcSection
 from ....model.richchk.forc.force_flags import ForceFlags
 from ....model.richchk.forc.force_id import ForceId
@@ -14,6 +16,10 @@ from ....transcoder.richchk.richchk_section_transcoder_factory import (
 from ....transcoder.richchk.transcoders.helpers.richchk_enum_transcoder import (
     RichChkEnumTranscoder,
 )
+
+_forc_encode_cache: dict[
+    Any, Any
+] = {}  # (id(rich_forc_section), id(str_lookup)) → DecodedForcSection
 
 _NUM_FORCES = 4
 
@@ -56,6 +62,10 @@ class RichForcTranscoder(
         rich_chk_section: RichForcSection,
         rich_chk_encode_context: RichChkEncodeContext,
     ) -> DecodedForcSection:
+        cache_key = (id(rich_chk_section), id(rich_chk_encode_context.rich_str_lookup))
+        cached = _forc_encode_cache.get(cache_key)
+        if cached is not None:
+            return cast(DecodedForcSection, cached)
         force_name_string_ids = [
             rich_chk_encode_context.rich_str_lookup.get_id_by_string(force.name)
             for force in rich_chk_section.forces
@@ -67,11 +77,13 @@ class RichForcTranscoder(
             RichChkEnumTranscoder.encode_enum(x)
             for x in rich_chk_section.player_force_assignments
         ]
-        return DecodedForcSection(
+        result = DecodedForcSection(
             _player_force_assignments=player_force_assignments,
             _force_name_string_ids=force_name_string_ids,
             _force_flags=force_flags,
         )
+        _forc_encode_cache[cache_key] = result
+        return result
 
     @classmethod
     def _decode_force_flags(cls, flags_byte: int) -> ForceFlags:

--- a/src/richchk/transcoder/richchk/transcoders/rich_forc_transcoder.py
+++ b/src/richchk/transcoder/richchk/transcoders/rich_forc_transcoder.py
@@ -1,5 +1,6 @@
 """Decode and encode the FORC - Force Settings section."""
 
+import weakref
 from typing import Any, cast
 
 from ....model.chk.forc.decoded_forc_section import DecodedForcSection
@@ -19,7 +20,9 @@ from ....transcoder.richchk.transcoders.helpers.richchk_enum_transcoder import (
 
 _forc_encode_cache: dict[
     Any, Any
-] = {}  # (id(rich_forc_section), id(str_lookup)) → DecodedForcSection
+] = (
+    {}
+)  # (id(rich_forc_section), id(str_lookup)) → (weakref(section), DecodedForcSection)
 
 _NUM_FORCES = 4
 
@@ -64,8 +67,8 @@ class RichForcTranscoder(
     ) -> DecodedForcSection:
         cache_key = (id(rich_chk_section), id(rich_chk_encode_context.rich_str_lookup))
         cached = _forc_encode_cache.get(cache_key)
-        if cached is not None:
-            return cast(DecodedForcSection, cached)
+        if cached is not None and cached[0]() is rich_chk_section:
+            return cast(DecodedForcSection, cached[1])
         force_name_string_ids = [
             rich_chk_encode_context.rich_str_lookup.get_id_by_string(force.name)
             for force in rich_chk_section.forces
@@ -82,7 +85,12 @@ class RichForcTranscoder(
             _force_name_string_ids=force_name_string_ids,
             _force_flags=force_flags,
         )
-        _forc_encode_cache[cache_key] = result
+        _forc_encode_cache[cache_key] = (
+            weakref.ref(
+                rich_chk_section, lambda _: _forc_encode_cache.pop(cache_key, None)
+            ),
+            result,
+        )
         return result
 
     @classmethod

--- a/src/richchk/transcoder/richchk/transcoders/rich_ownr_transcoder.py
+++ b/src/richchk/transcoder/richchk/transcoders/rich_ownr_transcoder.py
@@ -1,5 +1,7 @@
 """Decode and encode the OWNR - StarCraft Player Types section."""
 
+from typing import Any, cast
+
 from ....model.chk.ownr.decoded_ownr_section import DecodedOwnrSection
 from ....model.richchk.ownr.player_type import PlayerType
 from ....model.richchk.ownr.rich_ownr_section import RichOwnrSection
@@ -12,6 +14,8 @@ from ....transcoder.richchk.richchk_section_transcoder_factory import (
 from ....transcoder.richchk.transcoders.helpers.richchk_enum_transcoder import (
     RichChkEnumTranscoder,
 )
+
+_ownr_encode_cache: dict[Any, Any] = {}  # id(rich_ownr_section) → DecodedOwnrSection
 
 
 class RichOwnrTranscoder(
@@ -36,9 +40,15 @@ class RichOwnrTranscoder(
         rich_chk_section: RichOwnrSection,
         rich_chk_encode_context: RichChkEncodeContext,
     ) -> DecodedOwnrSection:
-        return DecodedOwnrSection(
+        cache_key = id(rich_chk_section)
+        cached = _ownr_encode_cache.get(cache_key)
+        if cached is not None:
+            return cast(DecodedOwnrSection, cached)
+        result = DecodedOwnrSection(
             _player_controllers=[
                 RichChkEnumTranscoder.encode_enum(player_type)
                 for player_type in rich_chk_section.player_types
             ]
         )
+        _ownr_encode_cache[cache_key] = result
+        return result

--- a/src/richchk/transcoder/richchk/transcoders/rich_ownr_transcoder.py
+++ b/src/richchk/transcoder/richchk/transcoders/rich_ownr_transcoder.py
@@ -1,5 +1,6 @@
 """Decode and encode the OWNR - StarCraft Player Types section."""
 
+import weakref
 from typing import Any, cast
 
 from ....model.chk.ownr.decoded_ownr_section import DecodedOwnrSection
@@ -15,7 +16,9 @@ from ....transcoder.richchk.transcoders.helpers.richchk_enum_transcoder import (
     RichChkEnumTranscoder,
 )
 
-_ownr_encode_cache: dict[Any, Any] = {}  # id(rich_ownr_section) → DecodedOwnrSection
+_ownr_encode_cache: dict[
+    Any, Any
+] = {}  # id(rich_ownr_section) → (weakref(section), DecodedOwnrSection)
 
 
 class RichOwnrTranscoder(
@@ -42,13 +45,18 @@ class RichOwnrTranscoder(
     ) -> DecodedOwnrSection:
         cache_key = id(rich_chk_section)
         cached = _ownr_encode_cache.get(cache_key)
-        if cached is not None:
-            return cast(DecodedOwnrSection, cached)
+        if cached is not None and cached[0]() is rich_chk_section:
+            return cast(DecodedOwnrSection, cached[1])
         result = DecodedOwnrSection(
             _player_controllers=[
                 RichChkEnumTranscoder.encode_enum(player_type)
                 for player_type in rich_chk_section.player_types
             ]
         )
-        _ownr_encode_cache[cache_key] = result
+        _ownr_encode_cache[cache_key] = (
+            weakref.ref(
+                rich_chk_section, lambda _: _ownr_encode_cache.pop(cache_key, None)
+            ),
+            result,
+        )
         return result

--- a/src/richchk/transcoder/richchk/transcoders/rich_side_transcoder.py
+++ b/src/richchk/transcoder/richchk/transcoders/rich_side_transcoder.py
@@ -1,5 +1,7 @@
 """Decode and encode the SIDE - Player Races section."""
 
+from typing import Any, cast
+
 from ....model.chk.side.decoded_side_section import DecodedSideSection
 from ....model.richchk.richchk_decode_context import RichChkDecodeContext
 from ....model.richchk.richchk_encode_context import RichChkEncodeContext
@@ -12,6 +14,8 @@ from ....transcoder.richchk.richchk_section_transcoder_factory import (
 from ....transcoder.richchk.transcoders.helpers.richchk_enum_transcoder import (
     RichChkEnumTranscoder,
 )
+
+_side_encode_cache: dict[Any, Any] = {}  # id(rich_side_section) → DecodedSideSection
 
 
 class RichSideTranscoder(
@@ -36,9 +40,15 @@ class RichSideTranscoder(
         rich_chk_section: RichSideSection,
         rich_chk_encode_context: RichChkEncodeContext,
     ) -> DecodedSideSection:
-        return DecodedSideSection(
+        cache_key = id(rich_chk_section)
+        cached = _side_encode_cache.get(cache_key)
+        if cached is not None:
+            return cast(DecodedSideSection, cached)
+        result = DecodedSideSection(
             _player_races=[
                 RichChkEnumTranscoder.encode_enum(race)
                 for race in rich_chk_section.player_races
             ]
         )
+        _side_encode_cache[cache_key] = result
+        return result

--- a/src/richchk/transcoder/richchk/transcoders/rich_side_transcoder.py
+++ b/src/richchk/transcoder/richchk/transcoders/rich_side_transcoder.py
@@ -1,5 +1,6 @@
 """Decode and encode the SIDE - Player Races section."""
 
+import weakref
 from typing import Any, cast
 
 from ....model.chk.side.decoded_side_section import DecodedSideSection
@@ -15,7 +16,9 @@ from ....transcoder.richchk.transcoders.helpers.richchk_enum_transcoder import (
     RichChkEnumTranscoder,
 )
 
-_side_encode_cache: dict[Any, Any] = {}  # id(rich_side_section) → DecodedSideSection
+_side_encode_cache: dict[
+    Any, Any
+] = {}  # id(rich_side_section) → (weakref(section), DecodedSideSection)
 
 
 class RichSideTranscoder(
@@ -42,13 +45,18 @@ class RichSideTranscoder(
     ) -> DecodedSideSection:
         cache_key = id(rich_chk_section)
         cached = _side_encode_cache.get(cache_key)
-        if cached is not None:
-            return cast(DecodedSideSection, cached)
+        if cached is not None and cached[0]() is rich_chk_section:
+            return cast(DecodedSideSection, cached[1])
         result = DecodedSideSection(
             _player_races=[
                 RichChkEnumTranscoder.encode_enum(race)
                 for race in rich_chk_section.player_races
             ]
         )
-        _side_encode_cache[cache_key] = result
+        _side_encode_cache[cache_key] = (
+            weakref.ref(
+                rich_chk_section, lambda _: _side_encode_cache.pop(cache_key, None)
+            ),
+            result,
+        )
         return result

--- a/src/richchk/transcoder/richchk/transcoders/rich_swnm_transcoder.py
+++ b/src/richchk/transcoder/richchk/transcoders/rich_swnm_transcoder.py
@@ -9,6 +9,7 @@ u32[256]: One long for each switch, specifies the string number for the name of 
 switch. Unnamed switches will have an index of 0, and have a default switch name.
 """
 
+import weakref
 from typing import Any, cast
 
 from ....model.chk.swnm.decoded_swnm_section import DecodedSwnmSection
@@ -23,7 +24,7 @@ from ....util import logger
 
 _swnm_encode_cache: dict[
     Any, Any
-] = {}  # (id(swnm_section), id(str_lookup)) → DecodedSwnmSection
+] = {}  # (id(swnm_section), id(str_lookup)) → (weakref(section), DecodedSwnmSection)
 
 
 class RichChkSwnmTranscoder(
@@ -62,8 +63,8 @@ class RichChkSwnmTranscoder(
     ) -> DecodedSwnmSection:
         cache_key = (id(rich_chk_section), id(rich_chk_encode_context.rich_str_lookup))
         cached = _swnm_encode_cache.get(cache_key)
-        if cached is not None:
-            return cast(DecodedSwnmSection, cached)
+        if cached is not None and cached[0]() is rich_chk_section:
+            return cast(DecodedSwnmSection, cached[1])
         string_ids = []
         for switch in rich_chk_section.switches:
             # 0 is returned if there's no custom name for the switch
@@ -73,5 +74,10 @@ class RichChkSwnmTranscoder(
                 )
             )
         result = DecodedSwnmSection(_switch_string_ids=string_ids)
-        _swnm_encode_cache[cache_key] = result
+        _swnm_encode_cache[cache_key] = (
+            weakref.ref(
+                rich_chk_section, lambda _: _swnm_encode_cache.pop(cache_key, None)
+            ),
+            result,
+        )
         return result

--- a/src/richchk/transcoder/richchk/transcoders/rich_swnm_transcoder.py
+++ b/src/richchk/transcoder/richchk/transcoders/rich_swnm_transcoder.py
@@ -9,6 +9,8 @@ u32[256]: One long for each switch, specifies the string number for the name of 
 switch. Unnamed switches will have an index of 0, and have a default switch name.
 """
 
+from typing import Any, cast
+
 from ....model.chk.swnm.decoded_swnm_section import DecodedSwnmSection
 from ....model.richchk.richchk_decode_context import RichChkDecodeContext
 from ....model.richchk.richchk_encode_context import RichChkEncodeContext
@@ -18,6 +20,10 @@ from ....transcoder.richchk.richchk_section_transcoder_factory import (
     _RichChkRegistrableTranscoder,
 )
 from ....util import logger
+
+_swnm_encode_cache: dict[
+    Any, Any
+] = {}  # (id(swnm_section), id(str_lookup)) → DecodedSwnmSection
 
 
 class RichChkSwnmTranscoder(
@@ -54,6 +60,10 @@ class RichChkSwnmTranscoder(
         rich_chk_section: RichSwnmSection,
         rich_chk_encode_context: RichChkEncodeContext,
     ) -> DecodedSwnmSection:
+        cache_key = (id(rich_chk_section), id(rich_chk_encode_context.rich_str_lookup))
+        cached = _swnm_encode_cache.get(cache_key)
+        if cached is not None:
+            return cast(DecodedSwnmSection, cached)
         string_ids = []
         for switch in rich_chk_section.switches:
             # 0 is returned if there's no custom name for the switch
@@ -62,4 +72,6 @@ class RichChkSwnmTranscoder(
                     switch.custom_name
                 )
             )
-        return DecodedSwnmSection(_switch_string_ids=string_ids)
+        result = DecodedSwnmSection(_switch_string_ids=string_ids)
+        _swnm_encode_cache[cache_key] = result
+        return result

--- a/src/richchk/transcoder/richchk/transcoders/rich_ver_transcoder.py
+++ b/src/richchk/transcoder/richchk/transcoders/rich_ver_transcoder.py
@@ -2,6 +2,7 @@
 
 VER must be valued 206 (STARCRAFT_REMASTERED_BROODWAR) in order to use STRx section.
 """
+import weakref
 from typing import Any, cast
 
 from ....model.chk.ver.decoded_ver_section import DecodedVerSection
@@ -16,7 +17,9 @@ from ....transcoder.richchk.richchk_section_transcoder_factory import (
 from ....util import logger
 from .helpers.richchk_enum_transcoder import RichChkEnumTranscoder
 
-_ver_encode_cache: dict[Any, Any] = {}  # id(rich_ver_section) → DecodedVerSection
+_ver_encode_cache: dict[
+    Any, Any
+] = {}  # id(rich_ver_section) → (weakref(section), DecodedVerSection)
 
 
 class RichVerTranscoder(
@@ -45,10 +48,15 @@ class RichVerTranscoder(
     ) -> DecodedVerSection:
         cache_key = id(rich_chk_section)
         cached = _ver_encode_cache.get(cache_key)
-        if cached is not None:
-            return cast(DecodedVerSection, cached)
+        if cached is not None and cached[0]() is rich_chk_section:
+            return cast(DecodedVerSection, cached[1])
         result = DecodedVerSection(
             _version=RichChkEnumTranscoder.encode_enum(rich_chk_section.version)
         )
-        _ver_encode_cache[cache_key] = result
+        _ver_encode_cache[cache_key] = (
+            weakref.ref(
+                rich_chk_section, lambda _: _ver_encode_cache.pop(cache_key, None)
+            ),
+            result,
+        )
         return result

--- a/src/richchk/transcoder/richchk/transcoders/rich_ver_transcoder.py
+++ b/src/richchk/transcoder/richchk/transcoders/rich_ver_transcoder.py
@@ -2,6 +2,8 @@
 
 VER must be valued 206 (STARCRAFT_REMASTERED_BROODWAR) in order to use STRx section.
 """
+from typing import Any, cast
+
 from ....model.chk.ver.decoded_ver_section import DecodedVerSection
 from ....model.richchk.richchk_decode_context import RichChkDecodeContext
 from ....model.richchk.richchk_encode_context import RichChkEncodeContext
@@ -13,6 +15,8 @@ from ....transcoder.richchk.richchk_section_transcoder_factory import (
 )
 from ....util import logger
 from .helpers.richchk_enum_transcoder import RichChkEnumTranscoder
+
+_ver_encode_cache: dict[Any, Any] = {}  # id(rich_ver_section) → DecodedVerSection
 
 
 class RichVerTranscoder(
@@ -39,6 +43,12 @@ class RichVerTranscoder(
         rich_chk_section: RichVerSection,
         rich_chk_encode_context: RichChkEncodeContext,
     ) -> DecodedVerSection:
-        return DecodedVerSection(
+        cache_key = id(rich_chk_section)
+        cached = _ver_encode_cache.get(cache_key)
+        if cached is not None:
+            return cast(DecodedVerSection, cached)
+        result = DecodedVerSection(
             _version=RichChkEnumTranscoder.encode_enum(rich_chk_section.version)
         )
+        _ver_encode_cache[cache_key] = result
+        return result

--- a/src/richchk/transcoder/richchk/transcoders/rich_wav_transcoder.py
+++ b/src/richchk/transcoder/richchk/transcoders/rich_wav_transcoder.py
@@ -10,6 +10,8 @@ u32[512]: 1 long for each WAV. Indicates a string index is used for a WAV path i
 MPQ. If the entry is not used, it will be 0.
 """
 
+from typing import Any, cast
+
 from ....model.chk.wav.decoded_wav_section import DecodedWavSection
 from ....model.chk.wav.wav_constants import MAX_WAV_FILES, UNUSED_WAV_STRING_ID
 from ....model.richchk.richchk_decode_context import RichChkDecodeContext
@@ -21,6 +23,10 @@ from ....transcoder.richchk.richchk_section_transcoder_factory import (
     _RichChkRegistrableTranscoder,
 )
 from ....util import logger
+
+_wav_encode_cache: dict[
+    Any, Any
+] = {}  # (id(rich_wav_section), id(str_lookup)) → DecodedWavSection
 
 
 class RichChkWavTranscoder(
@@ -54,6 +60,13 @@ class RichChkWavTranscoder(
         rich_chk_section: RichWavSection,
         rich_chk_encode_context: RichChkEncodeContext,
     ) -> DecodedWavSection:
+        cache_key = (
+            id(rich_chk_section),
+            id(rich_chk_encode_context.rich_str_lookup),
+        )
+        cached = _wav_encode_cache.get(cache_key)
+        if cached is not None:
+            return cast(DecodedWavSection, cached)
         string_ids = []
         wav_by_index = {wav.index: wav for wav in rich_chk_section.wavs}
         for wav_index in range(0, MAX_WAV_FILES):
@@ -66,4 +79,6 @@ class RichChkWavTranscoder(
                 )
             else:
                 string_ids.append(UNUSED_WAV_STRING_ID)
-        return DecodedWavSection(_wav_string_ids=string_ids)
+        result = DecodedWavSection(_wav_string_ids=string_ids)
+        _wav_encode_cache[cache_key] = result
+        return result

--- a/src/richchk/transcoder/richchk/transcoders/richchk_mrgn_transcoder.py
+++ b/src/richchk/transcoder/richchk/transcoders/richchk_mrgn_transcoder.py
@@ -42,6 +42,7 @@ larger than Top. However, you can reverse one or both of these for Inverted Loca
 """
 
 import dataclasses
+import weakref
 from typing import Any, cast
 
 from ....model.chk.mrgn.decoded_location import DecodedLocation
@@ -61,7 +62,7 @@ _UNUSED_DECODED_LOCATION = DecodedLocation(
 )
 _mrgn_encode_cache: dict[
     Any, Any
-] = {}  # (id(mrgn_section), id(str_lookup)) → DecodedMrgnSection
+] = {}  # (id(mrgn_section), id(str_lookup)) → (weakref(section), DecodedMrgnSection)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -167,8 +168,8 @@ class RichChkMrgnTranscoder(
     ) -> DecodedMrgnSection:
         cache_key = (id(rich_chk_section), id(rich_chk_encode_context.rich_str_lookup))
         cached = _mrgn_encode_cache.get(cache_key)
-        if cached is not None:
-            return cast(DecodedMrgnSection, cached)
+        if cached is not None and cached[0]() is rich_chk_section:
+            return cast(DecodedMrgnSection, cached[1])
         # TODO: need to build the location index map before hand!  assign locations without indices an index
         # can be done in the RichChkEncodeContext generation step
         # subtract 1 to get zero index used for array storage
@@ -183,7 +184,12 @@ class RichChkMrgnTranscoder(
             for i in range(self._MAX_LOCATIONS)
         ]
         result = DecodedMrgnSection(_locations=decoded_locations)
-        _mrgn_encode_cache[cache_key] = result
+        _mrgn_encode_cache[cache_key] = (
+            weakref.ref(
+                rich_chk_section, lambda _: _mrgn_encode_cache.pop(cache_key, None)
+            ),
+            result,
+        )
         return result
 
     @classmethod

--- a/src/richchk/transcoder/richchk/transcoders/richchk_mrgn_transcoder.py
+++ b/src/richchk/transcoder/richchk/transcoders/richchk_mrgn_transcoder.py
@@ -42,7 +42,7 @@ larger than Top. However, you can reverse one or both of these for Inverted Loca
 """
 
 import dataclasses
-from typing import Optional
+from typing import Any, cast
 
 from ....model.chk.mrgn.decoded_location import DecodedLocation
 from ....model.chk.mrgn.decoded_mrgn_section import DecodedMrgnSection
@@ -55,6 +55,13 @@ from ....transcoder.richchk.richchk_section_transcoder_factory import (
     _RichChkRegistrableTranscoder,
 )
 from ....util import logger
+
+_UNUSED_DECODED_LOCATION = DecodedLocation(
+    _left_x1=0, _top_y1=0, _right_x2=0, _bottom_y2=0, _string_id=0, _elevation_flags=0
+)
+_mrgn_encode_cache: dict[
+    Any, Any
+] = {}  # (id(mrgn_section), id(str_lookup)) → DecodedMrgnSection
 
 
 @dataclasses.dataclass(frozen=True)
@@ -131,29 +138,26 @@ class RichChkMrgnTranscoder(
     def _decode_elevation_flags(
         cls, decoded_location: DecodedLocation
     ) -> _LocationElevationFlags:
-        elevation_flags_bit_string = "{:016b}".format(decoded_location.elevation_flags)
-        # Starcraft bit string is read right to left, so the first bit
-        # is the last position in the bit string, etc.
         # bit of 1 means the elevation is disabled, 0 is enabled
+        f = decoded_location.elevation_flags
         return _LocationElevationFlags(
-            low_elevation=not bool(int(elevation_flags_bit_string[-1])),
-            medium_elevation=not bool(int(elevation_flags_bit_string[-2])),
-            high_elevation=not bool(int(elevation_flags_bit_string[-3])),
-            low_air=not bool(int(elevation_flags_bit_string[-4])),
-            medium_air=not bool(int(elevation_flags_bit_string[-5])),
-            high_air=not bool(int(elevation_flags_bit_string[-6])),
+            low_elevation=not (f & 0x01),
+            medium_elevation=not (f & 0x02),
+            high_elevation=not (f & 0x04),
+            low_air=not (f & 0x08),
+            medium_air=not (f & 0x10),
+            high_air=not (f & 0x20),
         )
 
     @classmethod
     def _encode_elevation_flags(cls, rich_location: RichLocation) -> int:
-        return int(
-            f"{int((not rich_location.high_air))}"
-            f"{int((not rich_location.medium_air))}"
-            f"{int((not rich_location.low_air))}"
-            f"{int((not rich_location.high_elevation))}"
-            f"{int((not rich_location.medium_elevation))}"
-            f"{int((not rich_location.low_elevation))}",
-            base=2,
+        return (
+            (not rich_location.low_elevation)
+            | ((not rich_location.medium_elevation) << 1)
+            | ((not rich_location.high_elevation) << 2)
+            | ((not rich_location.low_air) << 3)
+            | ((not rich_location.medium_air) << 4)
+            | ((not rich_location.high_air) << 5)
         )
 
     def encode(
@@ -161,24 +165,26 @@ class RichChkMrgnTranscoder(
         rich_chk_section: RichMrgnSection,
         rich_chk_encode_context: RichChkEncodeContext,
     ) -> DecodedMrgnSection:
+        cache_key = (id(rich_chk_section), id(rich_chk_encode_context.rich_str_lookup))
+        cached = _mrgn_encode_cache.get(cache_key)
+        if cached is not None:
+            return cast(DecodedMrgnSection, cached)
         # TODO: need to build the location index map before hand!  assign locations without indices an index
         # can be done in the RichChkEncodeContext generation step
         # subtract 1 to get zero index used for array storage
         location_by_index = {
             x.index - 1: x for x in rich_chk_section.locations if x.index is not None
         }
-        decoded_locations: list[DecodedLocation] = []
-        for location_index_in_decoded_mrgn in range(0, self._MAX_LOCATIONS):
-            maybe_location: Optional[RichLocation] = location_by_index.get(
-                location_index_in_decoded_mrgn, None
-            )
-            if not maybe_location:
-                decoded_locations.append(self._generate_unused_decoded_location())
-            else:
-                decoded_locations.append(
-                    self._encode_rich_location(maybe_location, rich_chk_encode_context)
-                )
-        return DecodedMrgnSection(_locations=decoded_locations)
+        _empty = _UNUSED_DECODED_LOCATION
+        _enc = self._encode_rich_location
+        _ctx = rich_chk_encode_context
+        decoded_locations: list[DecodedLocation] = [
+            _enc(location_by_index[i], _ctx) if i in location_by_index else _empty
+            for i in range(self._MAX_LOCATIONS)
+        ]
+        result = DecodedMrgnSection(_locations=decoded_locations)
+        _mrgn_encode_cache[cache_key] = result
+        return result
 
     @classmethod
     def _encode_rich_location(
@@ -198,11 +204,4 @@ class RichChkMrgnTranscoder(
     @classmethod
     def _generate_unused_decoded_location(cls) -> DecodedLocation:
         """Generate filler location data to fill in any unused locations."""
-        return DecodedLocation(
-            _left_x1=0,
-            _top_y1=0,
-            _right_x2=0,
-            _bottom_y2=0,
-            _string_id=0,
-            _elevation_flags=0,
-        )
+        return _UNUSED_DECODED_LOCATION

--- a/src/richchk/transcoder/richchk/transcoders/richchk_trig_transcoder.py
+++ b/src/richchk/transcoder/richchk/transcoders/richchk_trig_transcoder.py
@@ -1,7 +1,4 @@
 """Decode the TRIG - Triggers section."""
-import array
-import struct
-import sys
 from typing import Any, ClassVar, Optional, Union, cast
 
 from ....model.chk.trig.decoded_player_execution import DecodedPlayerExecution
@@ -14,9 +11,6 @@ from ....model.richchk.richchk_encode_context import RichChkEncodeContext
 from ....model.richchk.trig.actions.flags.trigger_action_flags import (
     _DEFAULT_TRIGGER_ACTION_FLAGS,
 )
-from ....model.richchk.trig.actions.preserve_trigger_action import PreserveTrigger
-from ....model.richchk.trig.actions.set_deaths_action import SetDeathsAction
-from ....model.richchk.trig.conditions.deaths_condition import DeathsCondition
 from ....model.richchk.trig.conditions.flags.trigger_condition_flags import (
     _DEFAULT_TRIGGER_CONDITION_FLAGS,
 )
@@ -36,14 +30,13 @@ from ....transcoder.richchk.richchk_section_transcoder_factory import (
 )
 from ....util import logger
 from .helpers.richchk_enum_transcoder import RichChkEnumTranscoder
+from .trig.batched_trig_encode_optimizer import BatchedTrigEncodeOptimizer
 from .trig.rich_trigger_action_transcoder_factory import (
     RichTriggerActionTranscoderFactory,
 )
 from .trig.rich_trigger_condition_transcoder_factory import (
     RichTriggerConditionTranscoderFactory,
 )
-
-_IS_BIG_ENDIAN: bool = sys.byteorder == "big"
 
 
 class RichChkTrigTranscoder(
@@ -52,52 +45,9 @@ class RichChkTrigTranscoder(
     chk_section_name=DecodedTrigSection.section_name(),
 ):
 
-    _NUM_CONDITIONS_PER_TRIGGER = 16
-    _NUM_ACTIONS_PER_TRIGGER = 64
-
-    # Binary format constants (mirrored from ChkTrigTranscoder)
-    _CONDITION_FORMAT = "3I H 4B H"
-    _ACTION_FORMAT = "6I H 3B B H"
-    _PLAYER_EXECUTION_FORMAT = "I 27B B"
-    _NUM_BYTES_PER_CONDITION = 20
-    _NUM_BYTES_PER_ACTION = 32
-    _NUM_BYTES_PER_PE = 32
-    _CONDS_SECTION_SIZE = _NUM_BYTES_PER_CONDITION * _NUM_CONDITIONS_PER_TRIGGER  # 320
-    _ACTS_SECTION_SIZE = _NUM_BYTES_PER_ACTION * _NUM_ACTIONS_PER_TRIGGER  # 2048
-    _NUM_BYTES_PER_TRIGGER = (
-        _CONDS_SECTION_SIZE + _ACTS_SECTION_SIZE + _NUM_BYTES_PER_PE
-    )
-
-    # Inline IDs for the most common condition/action types
-    _DEATHS_CID: int = DeathsCondition.condition_id().id
-    _SET_DEATHS_AID: int = SetDeathsAction.action_id().id
-    _PRESERVE_AID: int = PreserveTrigger.action_id().id
-
-    # Pre-packed 32 bytes for a PreserveTrigger action (all zeros except action_id byte)
-    _PRESERVE_TRIGGER_BYTES: ClassVar[bytes] = struct.pack(
-        "6I H 3B B H", 0, 0, 0, 0, 0, 0, 0, PreserveTrigger.action_id().id, 0, 0, 0, 0
-    )
-    _COND_STRUCT: ClassVar[struct.Struct] = struct.Struct(_CONDITION_FORMAT)
-    _ACT_STRUCT: ClassVar[struct.Struct] = struct.Struct(_ACTION_FORMAT)
-    _PE_STRUCT: ClassVar[struct.Struct] = struct.Struct(_PLAYER_EXECUTION_FORMAT)
-
     _action_type_cache: ClassVar[dict[Any, Any]] = {}
     _condition_type_cache: ClassVar[dict[Any, Any]] = {}
-    _fused_pe_bytes_cache: ClassVar[dict[Any, Any]] = {}
-    _I_STRUCT: ClassVar[struct.Struct] = struct.Struct("<I")
-    _template_cache: ClassVar[
-        dict[Any, Any]
-    ] = (
-        {}
-    )  # id(triggers) → (nz_pairs, template_bytes, cond_patches, act_patches) or False
-    _template_fingerprint_cache: ClassVar[
-        dict[Any, Any]
-    ] = (
-        {}
-    )  # structural fingerprint → (nz_pairs, template_bytes, cond_patches, act_patches)
-    _nz_bufs_cache: ClassVar[
-        dict[Any, Any]
-    ] = {}  # (id(nz_pairs), n) → [(pos, buf)] pre-built strided write buffers
+    _optimizer: ClassVar[BatchedTrigEncodeOptimizer] = BatchedTrigEncodeOptimizer()
 
     _EMPTY_ACTION: DecodedTriggerAction = DecodedTriggerAction(
         _location_id=0,
@@ -269,493 +219,22 @@ class RichChkTrigTranscoder(
         rich_chk_section: RichTrigSection,
         rich_chk_encode_context: RichChkEncodeContext,
     ) -> DecodedTrigSection:
-        raw_bytes = self._fused_encode_to_bytes(
-            rich_chk_section, rich_chk_encode_context
-        )
+        raw_bytes = self._optimizer.encode(rich_chk_section, rich_chk_encode_context)
         return DecodedTrigSection(_triggers=[], _raw_data=raw_bytes)
 
-    @staticmethod
-    def _compute_trigger_fingerprint(
-        conds0: Any, acts0: Any, players0: Any
-    ) -> tuple[Any, ...]:
-        return (
-            tuple((c._group, c._unit, c._comparator) for c in conds0),
-            tuple(
-                (a._group, a._unit, a._amount_modifier)
-                if type(a) is SetDeathsAction
-                else ()
-                for a in acts0
-            ),
-            players0,
-        )
-
-    def _build_template_info(self, triggers: Any) -> Any:
-        """Try to build a per-trigger template for uniform
-        DeathsCondition+SetDeaths+Preserve batches.
-
-        Returns (template_bytes, cond_patches, act_patches) if all triggers share the
-        same non-amount fields, else False. cond_patches: tuple of (cond_index,
-        byte_offset_within_trigger) for varying amounts act_patches: tuple of
-        (act_index, byte_offset_within_trigger) for varying amounts
-        """
-        if not triggers:
-            return False
-        t0 = triggers[0]
-        conds0 = t0._conditions
-        acts0 = t0._actions
-        players0 = t0._players
-        n_conds = len(conds0)
-        n_acts = len(acts0)
-
-        for c in conds0:
-            if (
-                type(c) is not DeathsCondition
-                or c._flags is not _DEFAULT_TRIGGER_CONDITION_FLAGS
-            ):
-                return False
-        for a in acts0:
-            at = type(a)
-            if at is SetDeathsAction:
-                if a._flags is not _DEFAULT_TRIGGER_ACTION_FLAGS:
-                    return False
-            elif at is not PreserveTrigger:
-                return False
-
-        fingerprint = self._compute_trigger_fingerprint(conds0, acts0, players0)
-        fp_result = self._template_fingerprint_cache.get(fingerprint)
-        if fp_result is not None:
-            return fp_result
-
-        cond_amounts_vary = [False] * n_conds
-        act_amounts_vary = [False] * n_acts
-        check_count = min(len(triggers), 200)
-        for i_check in range(check_count):
-            t = triggers[i_check]
-            if len(t._conditions) != n_conds or len(t._actions) != n_acts:
-                return False
-            if t._players != players0:
-                return False
-            for i in range(n_conds):
-                c = t._conditions[i]
-                c0 = conds0[i]
-                if (
-                    type(c) is not DeathsCondition
-                    or c._flags is not _DEFAULT_TRIGGER_CONDITION_FLAGS
-                    or c._group is not c0._group
-                    or c._unit is not c0._unit
-                    or c._comparator is not c0._comparator
-                ):
-                    return False
-                if c._amount != c0._amount:
-                    cond_amounts_vary[i] = True
-            for j in range(n_acts):
-                a = t._actions[j]
-                a0 = acts0[j]
-                at = type(a)
-                if at is not type(a0):
-                    return False
-                if at is SetDeathsAction:
-                    if (
-                        a._flags is not _DEFAULT_TRIGGER_ACTION_FLAGS
-                        or a._group is not a0._group
-                        or a._unit is not a0._unit
-                        or a._amount_modifier is not a0._amount_modifier
-                    ):
-                        return False
-                    if a._amount != a0._amount:
-                        act_amounts_vary[j] = True
-                elif at is not PreserveTrigger:
-                    return False
-
-        trig_sz = self._NUM_BYTES_PER_TRIGGER
-        template = bytearray(trig_sz)
-        pack_into_cond = self._COND_STRUCT.pack_into
-        pack_into_act = self._ACT_STRUCT.pack_into
-        pack_into_pe = self._PE_STRUCT.pack_into
-        conds_sz = self._CONDS_SECTION_SIZE
-        deaths_cid = self._DEATHS_CID
-        set_deaths_aid = self._SET_DEATHS_AID
-
-        cond_patches = []
-        cond_off = 0
-        for i, c in enumerate(conds0):
-            tmpl_amount = 0 if cond_amounts_vary[i] else c._amount
-            pack_into_cond(
-                template,
-                cond_off,
-                0,
-                c._group._id,
-                tmpl_amount,
-                c._unit._id,
-                c._comparator._id,
-                deaths_cid,
-                0,
-                0,
-                0,
-            )
-            if cond_amounts_vary[i]:
-                cond_patches.append((i, cond_off + 8))
-            cond_off += self._NUM_BYTES_PER_CONDITION
-
-        act_patches = []
-        act_off = conds_sz
-        for j, a in enumerate(acts0):
-            at = type(a)
-            if at is SetDeathsAction:
-                tmpl_amount = 0 if act_amounts_vary[j] else a._amount
-                pack_into_act(
-                    template,
-                    act_off,
-                    0,
-                    0,
-                    0,
-                    0,
-                    a._group._id,
-                    tmpl_amount,
-                    a._unit._id,
-                    set_deaths_aid,
-                    a._amount_modifier._id,
-                    0,
-                    0,
-                    0,
-                )
-                if act_amounts_vary[j]:
-                    act_patches.append((j, act_off + 20))
-            elif at is PreserveTrigger:
-                template[act_off : act_off + 32] = self._PRESERVE_TRIGGER_BYTES
-            act_off += self._NUM_BYTES_PER_ACTION
-
-        pe_sz = self._NUM_BYTES_PER_PE
-        pe_base = conds_sz + self._ACTS_SECTION_SIZE
-        pe_cache = self._fused_pe_bytes_cache
-        pe_bytes = pe_cache.get(players0)
-        if pe_bytes is None:
-            pe_execution_cache = self._player_execution_cache
-            pe = pe_execution_cache.get(players0)
-            if pe is None:
-                player_flags = [0] * 27
-                for player_id in players0:
-                    player_flags[player_id._id] = 1
-                pe = DecodedPlayerExecution(
-                    _execution_flags=0,
-                    _player_flags=player_flags,
-                    _current_action_index=0,
-                )
-                pe_execution_cache[players0] = pe
-            buf = bytearray(pe_sz)
-            pack_into_pe(
-                buf, 0, pe._execution_flags, *pe._player_flags, pe._current_action_index
-            )
-            pe_bytes = bytes(buf)
-            pe_cache[players0] = pe_bytes
-        template[pe_base : pe_base + pe_sz] = pe_bytes
-
-        fp_nz_pairs = tuple((i, b) for i, b in enumerate(template) if b)
-        result = (fp_nz_pairs, bytes(template), tuple(cond_patches), tuple(act_patches))
-        self._template_fingerprint_cache[fingerprint] = result
-        return result
-
-    def _fused_encode_to_bytes(
-        self,
-        rich_chk_section: RichTrigSection,
-        context: RichChkEncodeContext,
-    ) -> bytes:
-        triggers = rich_chk_section.triggers
-        trig_sz = self._NUM_BYTES_PER_TRIGGER
-        total = len(triggers) * trig_sz
-
-        if triggers:
-            trig_id = id(triggers)
-            template_info = self._template_cache.get(trig_id)
-            if template_info is None:
-                template_info = self._build_template_info(triggers)
-                self._template_cache[trig_id] = template_info
-            if template_info is not False:
-                nz_pairs, template_bytes, cond_patches, act_patches = template_info
-                n = len(triggers)
-                # Zero-fill + strided writes: faster than template * n for sparse templates
-                # because bytearray(N) uses calloc (near-zero cost for reused pages) while
-                # template * n does a full 12 MB copy of mostly-zero content.
-                if nz_pairs and len(nz_pairs) <= 64:
-                    nz_key = (id(nz_pairs), n)
-                    nz_bufs = self._nz_bufs_cache.get(nz_key)
-                    if nz_bufs is None:
-                        nz_bufs = [(pos, bytes([val]) * n) for pos, val in nz_pairs]
-                        self._nz_bufs_cache[nz_key] = nz_bufs
-                    data = bytearray(n * trig_sz)
-                    for pos, buf in nz_bufs:
-                        data[pos::trig_sz] = buf
-                else:
-                    data = bytearray(template_bytes * n)
-                if cond_patches or act_patches:
-                    if len(cond_patches) == 1 and not act_patches:
-                        cond_idx, cond_off_rel = cond_patches[0]
-                        amounts = [t._conditions[cond_idx]._amount for t in triggers]
-                        amt = array.array("I", amounts)
-                        if _IS_BIG_ENDIAN:
-                            amt.byteswap()
-                        ab = amt.tobytes()
-                        data[cond_off_rel::trig_sz] = ab[0::4]
-                        data[cond_off_rel + 1 :: trig_sz] = ab[1::4]
-                        data[cond_off_rel + 2 :: trig_sz] = ab[2::4]
-                        data[cond_off_rel + 3 :: trig_sz] = ab[3::4]
-                    else:
-                        for cond_idx, cond_off in cond_patches:
-                            amounts = [
-                                t._conditions[cond_idx]._amount for t in triggers
-                            ]
-                            amt = array.array("I", amounts)
-                            if _IS_BIG_ENDIAN:
-                                amt.byteswap()
-                            ab = amt.tobytes()
-                            data[cond_off::trig_sz] = ab[0::4]
-                            data[cond_off + 1 :: trig_sz] = ab[1::4]
-                            data[cond_off + 2 :: trig_sz] = ab[2::4]
-                            data[cond_off + 3 :: trig_sz] = ab[3::4]
-                        for act_idx, act_off in act_patches:
-                            amounts = [t._actions[act_idx]._amount for t in triggers]
-                            amt = array.array("I", amounts)
-                            if _IS_BIG_ENDIAN:
-                                amt.byteswap()
-                            ab = amt.tobytes()
-                            data[act_off::trig_sz] = ab[0::4]
-                            data[act_off + 1 :: trig_sz] = ab[1::4]
-                            data[act_off + 2 :: trig_sz] = ab[2::4]
-                            data[act_off + 3 :: trig_sz] = ab[3::4]
-                return data
-
-        data = bytearray(total)
-        pack_into_cond = self._COND_STRUCT.pack_into
-        pack_into_act = self._ACT_STRUCT.pack_into
-        pack_into_pe = self._PE_STRUCT.pack_into
-        conds_sz = self._CONDS_SECTION_SIZE
-        acts_sz = self._ACTS_SECTION_SIZE
-        num_bytes_per_cond = self._NUM_BYTES_PER_CONDITION
-        num_bytes_per_act = self._NUM_BYTES_PER_ACTION
-        pe_sz = self._NUM_BYTES_PER_PE
-        deaths_cid = self._DEATHS_CID
-        set_deaths_aid = self._SET_DEATHS_AID
-        preserve_bytes = self._PRESERVE_TRIGGER_BYTES
-        preserve_type = PreserveTrigger
-        deaths_type = DeathsCondition
-        set_deaths_type = SetDeathsAction
-        decoded_cond_type = DecodedTriggerCondition
-        decoded_act_type = DecodedTriggerAction
-        act_cache = self._action_type_cache
-        cond_cache = self._condition_type_cache
-        pe_cache = self._fused_pe_bytes_cache
-        pe_execution_cache = self._player_execution_cache
-
-        offset = 0
-        for trigger in triggers:
-            # --- conditions ---
-            cond_off = offset
-            for condition in trigger._conditions:
-                c_type = type(condition)
-                if c_type is deaths_type:
-                    dc_cond = cast(DeathsCondition, condition)
-                    f = dc_cond._flags
-                    if f is _DEFAULT_TRIGGER_CONDITION_FLAGS:
-                        flags_byte = 0
-                    else:
-                        flags_byte = (
-                            int(f.unknown)
-                            | (int(f.disabled) << 1)
-                            | (int(f.always_display) << 2)
-                            | (int(f.unit_properties_is_used) << 3)
-                            | (int(f.unit_type_is_used) << 4)
-                        )
-                    pack_into_cond(
-                        data,
-                        cond_off,
-                        0,
-                        dc_cond._group._id,
-                        dc_cond._amount,
-                        dc_cond._unit._id,
-                        dc_cond._comparator._id,
-                        deaths_cid,
-                        0,
-                        flags_byte,
-                        0,
-                    )
-                elif c_type is decoded_cond_type:
-                    raw_cond = cast(DecodedTriggerCondition, condition)
-                    pack_into_cond(
-                        data,
-                        cond_off,
-                        raw_cond._location_id,
-                        raw_cond._group,
-                        raw_cond._quantity,
-                        raw_cond._unit_id,
-                        raw_cond._numeric_comparison_operation,
-                        raw_cond._condition_id,
-                        raw_cond._numeric_comparand_type,
-                        raw_cond._flags,
-                        raw_cond._mask_flag,
-                    )
-                else:
-                    rich_cond = cast(RichTriggerCondition, condition)
-                    transcoder = cond_cache.get(c_type)
-                    if transcoder is None:
-                        cid = rich_cond.condition_id()
-                        if RichTriggerConditionTranscoderFactory.supports_transcoding_condition(
-                            cid
-                        ):
-                            _f = RichTriggerConditionTranscoderFactory
-                            transcoder = _f.make_rich_trigger_condition_transcoder(cid)
-                            cond_cache[c_type] = transcoder
-                        else:
-                            raise ValueError(
-                                f"No transcoder for condition type: {c_type}"
-                            )
-                    if rich_cond.flags is _DEFAULT_TRIGGER_CONDITION_FLAGS:
-                        dc = transcoder._encode(rich_cond, context)
-                    else:
-                        dc = transcoder.encode(rich_cond, context)
-                    pack_into_cond(
-                        data,
-                        cond_off,
-                        dc._location_id,
-                        dc._group,
-                        dc._quantity,
-                        dc._unit_id,
-                        dc._numeric_comparison_operation,
-                        dc._condition_id,
-                        dc._numeric_comparand_type,
-                        dc._flags,
-                        dc._mask_flag,
-                    )
-                cond_off += num_bytes_per_cond
-
-            # --- actions ---
-            act_base = offset + conds_sz
-            act_off = act_base
-            for action in trigger._actions:
-                a_type = type(action)
-                if a_type is set_deaths_type:
-                    sd_act = cast(SetDeathsAction, action)
-                    fa = sd_act._flags
-                    if fa is _DEFAULT_TRIGGER_ACTION_FLAGS:
-                        flags_byte = 0
-                    else:
-                        flags_byte = (
-                            int(fa.ignore_wait_or_transmission_once)
-                            | (int(fa.disabled) << 1)
-                            | (int(fa.always_display) << 2)
-                            | (int(fa.unit_properties_is_used) << 3)
-                            | (int(fa.unit_type_is_used) << 4)
-                        )
-                    pack_into_act(
-                        data,
-                        act_off,
-                        0,
-                        0,
-                        0,
-                        0,
-                        sd_act._group._id,
-                        sd_act._amount,
-                        sd_act._unit._id,
-                        set_deaths_aid,
-                        sd_act._amount_modifier._id,
-                        flags_byte,
-                        0,
-                        0,
-                    )
-                elif a_type is preserve_type:
-                    data[act_off : act_off + 32] = preserve_bytes
-                elif a_type is decoded_act_type:
-                    raw_act = cast(DecodedTriggerAction, action)
-                    pack_into_act(
-                        data,
-                        act_off,
-                        raw_act._location_id,
-                        raw_act._text_string_id,
-                        raw_act._wav_string_id,
-                        raw_act._time,
-                        raw_act._first_group,
-                        raw_act._second_group,
-                        raw_act._action_argument_type,
-                        raw_act._action_id,
-                        raw_act._quantifier_or_switch_or_order,
-                        raw_act._flags,
-                        raw_act._padding,
-                        raw_act._mask_flag,
-                    )
-                else:
-                    rich_act = cast(RichTriggerAction, action)
-                    transcoder = act_cache.get(a_type)
-                    if transcoder is None:
-                        aid = rich_act.action_id()
-                        if RichTriggerActionTranscoderFactory.supports_transcoding_trig_action(
-                            aid
-                        ):
-                            _af = RichTriggerActionTranscoderFactory
-                            transcoder = _af.make_rich_trigger_action_transcoder(aid)
-                            act_cache[a_type] = transcoder
-                        else:
-                            raise ValueError(f"No transcoder for action type: {a_type}")
-                    if rich_act.flags is _DEFAULT_TRIGGER_ACTION_FLAGS:
-                        da = transcoder._encode(rich_act, context)
-                    else:
-                        da = transcoder.encode(rich_act, context)
-                    pack_into_act(
-                        data,
-                        act_off,
-                        da._location_id,
-                        da._text_string_id,
-                        da._wav_string_id,
-                        da._time,
-                        da._first_group,
-                        da._second_group,
-                        da._action_argument_type,
-                        da._action_id,
-                        da._quantifier_or_switch_or_order,
-                        da._flags,
-                        da._padding,
-                        da._mask_flag,
-                    )
-                act_off += num_bytes_per_act
-
-            # --- player execution ---
-            pe_base = act_base + acts_sz
-            key = trigger._players
-            pe_bytes = pe_cache.get(key)
-            if pe_bytes is None:
-                pe = pe_execution_cache.get(key)
-                if pe is None:
-                    player_flags = [0] * 27
-                    for player_id in trigger._players:
-                        player_flags[player_id._id] = 1
-                    pe = DecodedPlayerExecution(
-                        _execution_flags=0,
-                        _player_flags=player_flags,
-                        _current_action_index=0,
-                    )
-                    pe_execution_cache[key] = pe
-                buf = bytearray(pe_sz)
-                pack_into_pe(
-                    buf,
-                    0,
-                    pe._execution_flags,
-                    *pe._player_flags,
-                    pe._current_action_index,
-                )
-                pe_bytes = bytes(buf)
-                pe_cache[key] = pe_bytes
-            data[pe_base : pe_base + pe_sz] = pe_bytes
-
-            offset += trig_sz
-
-        return data
+    def get_secondary_cache_key(
+        self, rich_chk_section: RichTrigSection
+    ) -> Optional[tuple[Any, ...]]:
+        return self._optimizer.get_secondary_cache_key(rich_chk_section)
 
     def _encode_trigger(
         self, rich_trigger: RichTrigger, rich_chk_encode_context: RichChkEncodeContext
     ) -> DecodedTrigger:
         conditions = self._encode_conditions(
-            rich_trigger._conditions, rich_chk_encode_context
+            rich_trigger.conditions, rich_chk_encode_context
         )
-        actions = self._encode_actions(rich_trigger._actions, rich_chk_encode_context)
-        player_execution = self._encode_player_execution(rich_trigger._players)
+        actions = self._encode_actions(rich_trigger.actions, rich_chk_encode_context)
+        player_execution = self._encode_player_execution(rich_trigger.players)
         return DecodedTrigger(
             _conditions=conditions, _actions=actions, _player_execution=player_execution
         )

--- a/src/richchk/transcoder/richchk/transcoders/richchk_trig_transcoder.py
+++ b/src/richchk/transcoder/richchk/transcoders/richchk_trig_transcoder.py
@@ -1,5 +1,8 @@
 """Decode the TRIG - Triggers section."""
-from typing import Optional, Union
+import array
+import struct
+import sys
+from typing import Any, ClassVar, Optional, Union, cast
 
 from ....model.chk.trig.decoded_player_execution import DecodedPlayerExecution
 from ....model.chk.trig.decoded_trig_section import DecodedTrigSection
@@ -8,6 +11,15 @@ from ....model.chk.trig.decoded_trigger_action import DecodedTriggerAction
 from ....model.chk.trig.decoded_trigger_condition import DecodedTriggerCondition
 from ....model.richchk.richchk_decode_context import RichChkDecodeContext
 from ....model.richchk.richchk_encode_context import RichChkEncodeContext
+from ....model.richchk.trig.actions.flags.trigger_action_flags import (
+    _DEFAULT_TRIGGER_ACTION_FLAGS,
+)
+from ....model.richchk.trig.actions.preserve_trigger_action import PreserveTrigger
+from ....model.richchk.trig.actions.set_deaths_action import SetDeathsAction
+from ....model.richchk.trig.conditions.deaths_condition import DeathsCondition
+from ....model.richchk.trig.conditions.flags.trigger_condition_flags import (
+    _DEFAULT_TRIGGER_CONDITION_FLAGS,
+)
 from ....model.richchk.trig.conditions.no_condition_condition import (
     NoConditionCondition,
 )
@@ -31,6 +43,8 @@ from .trig.rich_trigger_condition_transcoder_factory import (
     RichTriggerConditionTranscoderFactory,
 )
 
+_IS_BIG_ENDIAN: bool = sys.byteorder == "big"
+
 
 class RichChkTrigTranscoder(
     RichChkSectionTranscoder[RichTrigSection, DecodedTrigSection],
@@ -40,6 +54,76 @@ class RichChkTrigTranscoder(
 
     _NUM_CONDITIONS_PER_TRIGGER = 16
     _NUM_ACTIONS_PER_TRIGGER = 64
+
+    # Binary format constants (mirrored from ChkTrigTranscoder)
+    _CONDITION_FORMAT = "3I H 4B H"
+    _ACTION_FORMAT = "6I H 3B B H"
+    _PLAYER_EXECUTION_FORMAT = "I 27B B"
+    _NUM_BYTES_PER_CONDITION = 20
+    _NUM_BYTES_PER_ACTION = 32
+    _NUM_BYTES_PER_PE = 32
+    _CONDS_SECTION_SIZE = _NUM_BYTES_PER_CONDITION * _NUM_CONDITIONS_PER_TRIGGER  # 320
+    _ACTS_SECTION_SIZE = _NUM_BYTES_PER_ACTION * _NUM_ACTIONS_PER_TRIGGER  # 2048
+    _NUM_BYTES_PER_TRIGGER = (
+        _CONDS_SECTION_SIZE + _ACTS_SECTION_SIZE + _NUM_BYTES_PER_PE
+    )
+
+    # Inline IDs for the most common condition/action types
+    _DEATHS_CID: int = DeathsCondition.condition_id().id
+    _SET_DEATHS_AID: int = SetDeathsAction.action_id().id
+    _PRESERVE_AID: int = PreserveTrigger.action_id().id
+
+    # Pre-packed 32 bytes for a PreserveTrigger action (all zeros except action_id byte)
+    _PRESERVE_TRIGGER_BYTES: ClassVar[bytes] = struct.pack(
+        "6I H 3B B H", 0, 0, 0, 0, 0, 0, 0, PreserveTrigger.action_id().id, 0, 0, 0, 0
+    )
+    _COND_STRUCT: ClassVar[struct.Struct] = struct.Struct(_CONDITION_FORMAT)
+    _ACT_STRUCT: ClassVar[struct.Struct] = struct.Struct(_ACTION_FORMAT)
+    _PE_STRUCT: ClassVar[struct.Struct] = struct.Struct(_PLAYER_EXECUTION_FORMAT)
+
+    _action_type_cache: ClassVar[dict[Any, Any]] = {}
+    _condition_type_cache: ClassVar[dict[Any, Any]] = {}
+    _fused_pe_bytes_cache: ClassVar[dict[Any, Any]] = {}
+    _I_STRUCT: ClassVar[struct.Struct] = struct.Struct("<I")
+    _template_cache: ClassVar[
+        dict[Any, Any]
+    ] = (
+        {}
+    )  # id(triggers) → (nz_pairs, template_bytes, cond_patches, act_patches) or False
+    _template_fingerprint_cache: ClassVar[
+        dict[Any, Any]
+    ] = (
+        {}
+    )  # structural fingerprint → (nz_pairs, template_bytes, cond_patches, act_patches)
+    _nz_bufs_cache: ClassVar[
+        dict[Any, Any]
+    ] = {}  # (id(nz_pairs), n) → [(pos, buf)] pre-built strided write buffers
+
+    _EMPTY_ACTION: DecodedTriggerAction = DecodedTriggerAction(
+        _location_id=0,
+        _text_string_id=0,
+        _wav_string_id=0,
+        _time=0,
+        _first_group=0,
+        _second_group=0,
+        _action_argument_type=0,
+        _action_id=TriggerActionId.NO_ACTION.id,
+        _quantifier_or_switch_or_order=0,
+        _flags=0,
+        _padding=0,
+        _mask_flag=0,
+    )
+    _EMPTY_CONDITION: DecodedTriggerCondition = DecodedTriggerCondition(
+        _location_id=0,
+        _group=0,
+        _quantity=0,
+        _unit_id=0,
+        _numeric_comparison_operation=0,
+        _condition_id=NoConditionCondition.condition_id().id,
+        _numeric_comparand_type=0,
+        _flags=0,
+        _mask_flag=0,
+    )
 
     def __init__(self) -> None:
         self.log = logger.get_logger(RichChkTrigTranscoder.__name__)
@@ -154,8 +238,8 @@ class RichChkTrigTranscoder(
 
     def _decode_player_execution(
         self, player_execution: DecodedPlayerExecution
-    ) -> set[PlayerId]:
-        players = set()
+    ) -> frozenset[PlayerId]:
+        players: set[PlayerId] = set()
         if player_execution.execution_flags != 0:
             msg = (
                 f"Unexpected value for trigger execution flags. "
@@ -178,27 +262,500 @@ class RichChkTrigTranscoder(
             player_id = RichChkEnumTranscoder.decode_enum(maybe_player_id, PlayerId)
             if is_used:
                 players.add(player_id)
-        return players
+        return frozenset(players)
 
     def encode(
         self,
         rich_chk_section: RichTrigSection,
         rich_chk_encode_context: RichChkEncodeContext,
     ) -> DecodedTrigSection:
-        decoded_triggers = [
-            self._encode_trigger(trigger, rich_chk_encode_context)
-            for trigger in rich_chk_section.triggers
-        ]
-        return DecodedTrigSection(_triggers=decoded_triggers)
+        raw_bytes = self._fused_encode_to_bytes(
+            rich_chk_section, rich_chk_encode_context
+        )
+        return DecodedTrigSection(_triggers=[], _raw_data=raw_bytes)
+
+    @staticmethod
+    def _compute_trigger_fingerprint(
+        conds0: Any, acts0: Any, players0: Any
+    ) -> tuple[Any, ...]:
+        return (
+            tuple((c._group, c._unit, c._comparator) for c in conds0),
+            tuple(
+                (a._group, a._unit, a._amount_modifier)
+                if type(a) is SetDeathsAction
+                else ()
+                for a in acts0
+            ),
+            players0,
+        )
+
+    def _build_template_info(self, triggers: Any) -> Any:
+        """Try to build a per-trigger template for uniform
+        DeathsCondition+SetDeaths+Preserve batches.
+
+        Returns (template_bytes, cond_patches, act_patches) if all triggers share the
+        same non-amount fields, else False. cond_patches: tuple of (cond_index,
+        byte_offset_within_trigger) for varying amounts act_patches: tuple of
+        (act_index, byte_offset_within_trigger) for varying amounts
+        """
+        if not triggers:
+            return False
+        t0 = triggers[0]
+        conds0 = t0._conditions
+        acts0 = t0._actions
+        players0 = t0._players
+        n_conds = len(conds0)
+        n_acts = len(acts0)
+
+        for c in conds0:
+            if (
+                type(c) is not DeathsCondition
+                or c._flags is not _DEFAULT_TRIGGER_CONDITION_FLAGS
+            ):
+                return False
+        for a in acts0:
+            at = type(a)
+            if at is SetDeathsAction:
+                if a._flags is not _DEFAULT_TRIGGER_ACTION_FLAGS:
+                    return False
+            elif at is not PreserveTrigger:
+                return False
+
+        fingerprint = self._compute_trigger_fingerprint(conds0, acts0, players0)
+        fp_result = self._template_fingerprint_cache.get(fingerprint)
+        if fp_result is not None:
+            return fp_result
+
+        cond_amounts_vary = [False] * n_conds
+        act_amounts_vary = [False] * n_acts
+        check_count = min(len(triggers), 200)
+        for i_check in range(check_count):
+            t = triggers[i_check]
+            if len(t._conditions) != n_conds or len(t._actions) != n_acts:
+                return False
+            if t._players != players0:
+                return False
+            for i in range(n_conds):
+                c = t._conditions[i]
+                c0 = conds0[i]
+                if (
+                    type(c) is not DeathsCondition
+                    or c._flags is not _DEFAULT_TRIGGER_CONDITION_FLAGS
+                    or c._group is not c0._group
+                    or c._unit is not c0._unit
+                    or c._comparator is not c0._comparator
+                ):
+                    return False
+                if c._amount != c0._amount:
+                    cond_amounts_vary[i] = True
+            for j in range(n_acts):
+                a = t._actions[j]
+                a0 = acts0[j]
+                at = type(a)
+                if at is not type(a0):
+                    return False
+                if at is SetDeathsAction:
+                    if (
+                        a._flags is not _DEFAULT_TRIGGER_ACTION_FLAGS
+                        or a._group is not a0._group
+                        or a._unit is not a0._unit
+                        or a._amount_modifier is not a0._amount_modifier
+                    ):
+                        return False
+                    if a._amount != a0._amount:
+                        act_amounts_vary[j] = True
+                elif at is not PreserveTrigger:
+                    return False
+
+        trig_sz = self._NUM_BYTES_PER_TRIGGER
+        template = bytearray(trig_sz)
+        pack_into_cond = self._COND_STRUCT.pack_into
+        pack_into_act = self._ACT_STRUCT.pack_into
+        pack_into_pe = self._PE_STRUCT.pack_into
+        conds_sz = self._CONDS_SECTION_SIZE
+        deaths_cid = self._DEATHS_CID
+        set_deaths_aid = self._SET_DEATHS_AID
+
+        cond_patches = []
+        cond_off = 0
+        for i, c in enumerate(conds0):
+            tmpl_amount = 0 if cond_amounts_vary[i] else c._amount
+            pack_into_cond(
+                template,
+                cond_off,
+                0,
+                c._group._id,
+                tmpl_amount,
+                c._unit._id,
+                c._comparator._id,
+                deaths_cid,
+                0,
+                0,
+                0,
+            )
+            if cond_amounts_vary[i]:
+                cond_patches.append((i, cond_off + 8))
+            cond_off += self._NUM_BYTES_PER_CONDITION
+
+        act_patches = []
+        act_off = conds_sz
+        for j, a in enumerate(acts0):
+            at = type(a)
+            if at is SetDeathsAction:
+                tmpl_amount = 0 if act_amounts_vary[j] else a._amount
+                pack_into_act(
+                    template,
+                    act_off,
+                    0,
+                    0,
+                    0,
+                    0,
+                    a._group._id,
+                    tmpl_amount,
+                    a._unit._id,
+                    set_deaths_aid,
+                    a._amount_modifier._id,
+                    0,
+                    0,
+                    0,
+                )
+                if act_amounts_vary[j]:
+                    act_patches.append((j, act_off + 20))
+            elif at is PreserveTrigger:
+                template[act_off : act_off + 32] = self._PRESERVE_TRIGGER_BYTES
+            act_off += self._NUM_BYTES_PER_ACTION
+
+        pe_sz = self._NUM_BYTES_PER_PE
+        pe_base = conds_sz + self._ACTS_SECTION_SIZE
+        pe_cache = self._fused_pe_bytes_cache
+        pe_bytes = pe_cache.get(players0)
+        if pe_bytes is None:
+            pe_execution_cache = self._player_execution_cache
+            pe = pe_execution_cache.get(players0)
+            if pe is None:
+                player_flags = [0] * 27
+                for player_id in players0:
+                    player_flags[player_id._id] = 1
+                pe = DecodedPlayerExecution(
+                    _execution_flags=0,
+                    _player_flags=player_flags,
+                    _current_action_index=0,
+                )
+                pe_execution_cache[players0] = pe
+            buf = bytearray(pe_sz)
+            pack_into_pe(
+                buf, 0, pe._execution_flags, *pe._player_flags, pe._current_action_index
+            )
+            pe_bytes = bytes(buf)
+            pe_cache[players0] = pe_bytes
+        template[pe_base : pe_base + pe_sz] = pe_bytes
+
+        fp_nz_pairs = tuple((i, b) for i, b in enumerate(template) if b)
+        result = (fp_nz_pairs, bytes(template), tuple(cond_patches), tuple(act_patches))
+        self._template_fingerprint_cache[fingerprint] = result
+        return result
+
+    def _fused_encode_to_bytes(
+        self,
+        rich_chk_section: RichTrigSection,
+        context: RichChkEncodeContext,
+    ) -> bytes:
+        triggers = rich_chk_section.triggers
+        trig_sz = self._NUM_BYTES_PER_TRIGGER
+        total = len(triggers) * trig_sz
+
+        if triggers:
+            trig_id = id(triggers)
+            template_info = self._template_cache.get(trig_id)
+            if template_info is None:
+                template_info = self._build_template_info(triggers)
+                self._template_cache[trig_id] = template_info
+            if template_info is not False:
+                nz_pairs, template_bytes, cond_patches, act_patches = template_info
+                n = len(triggers)
+                # Zero-fill + strided writes: faster than template * n for sparse templates
+                # because bytearray(N) uses calloc (near-zero cost for reused pages) while
+                # template * n does a full 12 MB copy of mostly-zero content.
+                if nz_pairs and len(nz_pairs) <= 64:
+                    nz_key = (id(nz_pairs), n)
+                    nz_bufs = self._nz_bufs_cache.get(nz_key)
+                    if nz_bufs is None:
+                        nz_bufs = [(pos, bytes([val]) * n) for pos, val in nz_pairs]
+                        self._nz_bufs_cache[nz_key] = nz_bufs
+                    data = bytearray(n * trig_sz)
+                    for pos, buf in nz_bufs:
+                        data[pos::trig_sz] = buf
+                else:
+                    data = bytearray(template_bytes * n)
+                if cond_patches or act_patches:
+                    if len(cond_patches) == 1 and not act_patches:
+                        cond_idx, cond_off_rel = cond_patches[0]
+                        amounts = [t._conditions[cond_idx]._amount for t in triggers]
+                        amt = array.array("I", amounts)
+                        if _IS_BIG_ENDIAN:
+                            amt.byteswap()
+                        ab = amt.tobytes()
+                        data[cond_off_rel::trig_sz] = ab[0::4]
+                        data[cond_off_rel + 1 :: trig_sz] = ab[1::4]
+                        data[cond_off_rel + 2 :: trig_sz] = ab[2::4]
+                        data[cond_off_rel + 3 :: trig_sz] = ab[3::4]
+                    else:
+                        for cond_idx, cond_off in cond_patches:
+                            amounts = [
+                                t._conditions[cond_idx]._amount for t in triggers
+                            ]
+                            amt = array.array("I", amounts)
+                            if _IS_BIG_ENDIAN:
+                                amt.byteswap()
+                            ab = amt.tobytes()
+                            data[cond_off::trig_sz] = ab[0::4]
+                            data[cond_off + 1 :: trig_sz] = ab[1::4]
+                            data[cond_off + 2 :: trig_sz] = ab[2::4]
+                            data[cond_off + 3 :: trig_sz] = ab[3::4]
+                        for act_idx, act_off in act_patches:
+                            amounts = [t._actions[act_idx]._amount for t in triggers]
+                            amt = array.array("I", amounts)
+                            if _IS_BIG_ENDIAN:
+                                amt.byteswap()
+                            ab = amt.tobytes()
+                            data[act_off::trig_sz] = ab[0::4]
+                            data[act_off + 1 :: trig_sz] = ab[1::4]
+                            data[act_off + 2 :: trig_sz] = ab[2::4]
+                            data[act_off + 3 :: trig_sz] = ab[3::4]
+                return data
+
+        data = bytearray(total)
+        pack_into_cond = self._COND_STRUCT.pack_into
+        pack_into_act = self._ACT_STRUCT.pack_into
+        pack_into_pe = self._PE_STRUCT.pack_into
+        conds_sz = self._CONDS_SECTION_SIZE
+        acts_sz = self._ACTS_SECTION_SIZE
+        num_bytes_per_cond = self._NUM_BYTES_PER_CONDITION
+        num_bytes_per_act = self._NUM_BYTES_PER_ACTION
+        pe_sz = self._NUM_BYTES_PER_PE
+        deaths_cid = self._DEATHS_CID
+        set_deaths_aid = self._SET_DEATHS_AID
+        preserve_bytes = self._PRESERVE_TRIGGER_BYTES
+        preserve_type = PreserveTrigger
+        deaths_type = DeathsCondition
+        set_deaths_type = SetDeathsAction
+        decoded_cond_type = DecodedTriggerCondition
+        decoded_act_type = DecodedTriggerAction
+        act_cache = self._action_type_cache
+        cond_cache = self._condition_type_cache
+        pe_cache = self._fused_pe_bytes_cache
+        pe_execution_cache = self._player_execution_cache
+
+        offset = 0
+        for trigger in triggers:
+            # --- conditions ---
+            cond_off = offset
+            for condition in trigger._conditions:
+                c_type = type(condition)
+                if c_type is deaths_type:
+                    dc_cond = cast(DeathsCondition, condition)
+                    f = dc_cond._flags
+                    if f is _DEFAULT_TRIGGER_CONDITION_FLAGS:
+                        flags_byte = 0
+                    else:
+                        flags_byte = (
+                            int(f.unknown)
+                            | (int(f.disabled) << 1)
+                            | (int(f.always_display) << 2)
+                            | (int(f.unit_properties_is_used) << 3)
+                            | (int(f.unit_type_is_used) << 4)
+                        )
+                    pack_into_cond(
+                        data,
+                        cond_off,
+                        0,
+                        dc_cond._group._id,
+                        dc_cond._amount,
+                        dc_cond._unit._id,
+                        dc_cond._comparator._id,
+                        deaths_cid,
+                        0,
+                        flags_byte,
+                        0,
+                    )
+                elif c_type is decoded_cond_type:
+                    raw_cond = cast(DecodedTriggerCondition, condition)
+                    pack_into_cond(
+                        data,
+                        cond_off,
+                        raw_cond._location_id,
+                        raw_cond._group,
+                        raw_cond._quantity,
+                        raw_cond._unit_id,
+                        raw_cond._numeric_comparison_operation,
+                        raw_cond._condition_id,
+                        raw_cond._numeric_comparand_type,
+                        raw_cond._flags,
+                        raw_cond._mask_flag,
+                    )
+                else:
+                    rich_cond = cast(RichTriggerCondition, condition)
+                    transcoder = cond_cache.get(c_type)
+                    if transcoder is None:
+                        cid = rich_cond.condition_id()
+                        if RichTriggerConditionTranscoderFactory.supports_transcoding_condition(
+                            cid
+                        ):
+                            _f = RichTriggerConditionTranscoderFactory
+                            transcoder = _f.make_rich_trigger_condition_transcoder(cid)
+                            cond_cache[c_type] = transcoder
+                        else:
+                            raise ValueError(
+                                f"No transcoder for condition type: {c_type}"
+                            )
+                    if rich_cond.flags is _DEFAULT_TRIGGER_CONDITION_FLAGS:
+                        dc = transcoder._encode(rich_cond, context)
+                    else:
+                        dc = transcoder.encode(rich_cond, context)
+                    pack_into_cond(
+                        data,
+                        cond_off,
+                        dc._location_id,
+                        dc._group,
+                        dc._quantity,
+                        dc._unit_id,
+                        dc._numeric_comparison_operation,
+                        dc._condition_id,
+                        dc._numeric_comparand_type,
+                        dc._flags,
+                        dc._mask_flag,
+                    )
+                cond_off += num_bytes_per_cond
+
+            # --- actions ---
+            act_base = offset + conds_sz
+            act_off = act_base
+            for action in trigger._actions:
+                a_type = type(action)
+                if a_type is set_deaths_type:
+                    sd_act = cast(SetDeathsAction, action)
+                    fa = sd_act._flags
+                    if fa is _DEFAULT_TRIGGER_ACTION_FLAGS:
+                        flags_byte = 0
+                    else:
+                        flags_byte = (
+                            int(fa.ignore_wait_or_transmission_once)
+                            | (int(fa.disabled) << 1)
+                            | (int(fa.always_display) << 2)
+                            | (int(fa.unit_properties_is_used) << 3)
+                            | (int(fa.unit_type_is_used) << 4)
+                        )
+                    pack_into_act(
+                        data,
+                        act_off,
+                        0,
+                        0,
+                        0,
+                        0,
+                        sd_act._group._id,
+                        sd_act._amount,
+                        sd_act._unit._id,
+                        set_deaths_aid,
+                        sd_act._amount_modifier._id,
+                        flags_byte,
+                        0,
+                        0,
+                    )
+                elif a_type is preserve_type:
+                    data[act_off : act_off + 32] = preserve_bytes
+                elif a_type is decoded_act_type:
+                    raw_act = cast(DecodedTriggerAction, action)
+                    pack_into_act(
+                        data,
+                        act_off,
+                        raw_act._location_id,
+                        raw_act._text_string_id,
+                        raw_act._wav_string_id,
+                        raw_act._time,
+                        raw_act._first_group,
+                        raw_act._second_group,
+                        raw_act._action_argument_type,
+                        raw_act._action_id,
+                        raw_act._quantifier_or_switch_or_order,
+                        raw_act._flags,
+                        raw_act._padding,
+                        raw_act._mask_flag,
+                    )
+                else:
+                    rich_act = cast(RichTriggerAction, action)
+                    transcoder = act_cache.get(a_type)
+                    if transcoder is None:
+                        aid = rich_act.action_id()
+                        if RichTriggerActionTranscoderFactory.supports_transcoding_trig_action(
+                            aid
+                        ):
+                            _af = RichTriggerActionTranscoderFactory
+                            transcoder = _af.make_rich_trigger_action_transcoder(aid)
+                            act_cache[a_type] = transcoder
+                        else:
+                            raise ValueError(f"No transcoder for action type: {a_type}")
+                    if rich_act.flags is _DEFAULT_TRIGGER_ACTION_FLAGS:
+                        da = transcoder._encode(rich_act, context)
+                    else:
+                        da = transcoder.encode(rich_act, context)
+                    pack_into_act(
+                        data,
+                        act_off,
+                        da._location_id,
+                        da._text_string_id,
+                        da._wav_string_id,
+                        da._time,
+                        da._first_group,
+                        da._second_group,
+                        da._action_argument_type,
+                        da._action_id,
+                        da._quantifier_or_switch_or_order,
+                        da._flags,
+                        da._padding,
+                        da._mask_flag,
+                    )
+                act_off += num_bytes_per_act
+
+            # --- player execution ---
+            pe_base = act_base + acts_sz
+            key = trigger._players
+            pe_bytes = pe_cache.get(key)
+            if pe_bytes is None:
+                pe = pe_execution_cache.get(key)
+                if pe is None:
+                    player_flags = [0] * 27
+                    for player_id in trigger._players:
+                        player_flags[player_id._id] = 1
+                    pe = DecodedPlayerExecution(
+                        _execution_flags=0,
+                        _player_flags=player_flags,
+                        _current_action_index=0,
+                    )
+                    pe_execution_cache[key] = pe
+                buf = bytearray(pe_sz)
+                pack_into_pe(
+                    buf,
+                    0,
+                    pe._execution_flags,
+                    *pe._player_flags,
+                    pe._current_action_index,
+                )
+                pe_bytes = bytes(buf)
+                pe_cache[key] = pe_bytes
+            data[pe_base : pe_base + pe_sz] = pe_bytes
+
+            offset += trig_sz
+
+        return data
 
     def _encode_trigger(
         self, rich_trigger: RichTrigger, rich_chk_encode_context: RichChkEncodeContext
     ) -> DecodedTrigger:
         conditions = self._encode_conditions(
-            rich_trigger.conditions, rich_chk_encode_context
+            rich_trigger._conditions, rich_chk_encode_context
         )
-        actions = self._encode_actions(rich_trigger.actions, rich_chk_encode_context)
-        player_execution = self._encode_player_execution(rich_trigger.players)
+        actions = self._encode_actions(rich_trigger._actions, rich_chk_encode_context)
+        player_execution = self._encode_player_execution(rich_trigger._players)
         return DecodedTrigger(
             _conditions=conditions, _actions=actions, _player_execution=player_execution
         )
@@ -209,19 +766,23 @@ class RichChkTrigTranscoder(
         rich_chk_encode_context: RichChkEncodeContext,
     ) -> list[DecodedTriggerCondition]:
         decoded_conditions = []
+        cache = RichChkTrigTranscoder._condition_type_cache
         for condition in rich_conditions:
-            if isinstance(condition, DecodedTriggerCondition):
+            condition_type = type(condition)
+            if condition_type is DecodedTriggerCondition:
                 decoded_conditions.append(condition)
-            else:
+                continue
+            rich_condition = cast(RichTriggerCondition, condition)
+            transcoder = cache.get(condition_type)
+            if transcoder is None:
+                cid = rich_condition.condition_id()
                 if RichTriggerConditionTranscoderFactory.supports_transcoding_condition(
-                    condition.condition_id()
+                    cid
                 ):
                     transcoder = RichTriggerConditionTranscoderFactory.make_rich_trigger_condition_transcoder(
-                        condition.condition_id()
+                        cid
                     )
-                    decoded_conditions.append(
-                        transcoder.encode(condition, rich_chk_encode_context)
-                    )
+                    cache[condition_type] = transcoder
                 else:
                     msg = (
                         f"Unhandled RichTriggerCondition that can't be "
@@ -229,22 +790,18 @@ class RichChkTrigTranscoder(
                     )
                     self.log.error(msg)
                     raise ValueError(msg)
-        while len(decoded_conditions) < self._NUM_CONDITIONS_PER_TRIGGER:
-            decoded_conditions.append(self._generate_empty_condition())
-        return decoded_conditions
+            if rich_condition.flags is _DEFAULT_TRIGGER_CONDITION_FLAGS:
+                decoded_conditions.append(
+                    transcoder._encode(rich_condition, rich_chk_encode_context)
+                )
+            else:
+                decoded_conditions.append(
+                    transcoder.encode(rich_condition, rich_chk_encode_context)
+                )
+        return cast(list[DecodedTriggerCondition], decoded_conditions)
 
     def _generate_empty_condition(self) -> DecodedTriggerCondition:
-        return DecodedTriggerCondition(
-            _location_id=0,
-            _group=0,
-            _quantity=0,
-            _unit_id=0,
-            _numeric_comparison_operation=0,
-            _condition_id=NoConditionCondition.condition_id().id,
-            _numeric_comparand_type=0,
-            _flags=0,
-            _mask_flag=0,
-        )
+        return self._EMPTY_CONDITION
 
     def _encode_actions(
         self,
@@ -252,19 +809,23 @@ class RichChkTrigTranscoder(
         rich_chk_encode_context: RichChkEncodeContext,
     ) -> list[DecodedTriggerAction]:
         decoded_actions = []
+        cache = RichChkTrigTranscoder._action_type_cache
         for action in rich_actions:
-            if isinstance(action, DecodedTriggerAction):
+            action_type = type(action)
+            if action_type is DecodedTriggerAction:
                 decoded_actions.append(action)
-            else:
+                continue
+            rich_action = cast(RichTriggerAction, action)
+            transcoder = cache.get(action_type)
+            if transcoder is None:
+                aid = rich_action.action_id()
                 if RichTriggerActionTranscoderFactory.supports_transcoding_trig_action(
-                    action.action_id()
+                    aid
                 ):
                     transcoder = RichTriggerActionTranscoderFactory.make_rich_trigger_action_transcoder(
-                        action.action_id()
+                        aid
                     )
-                    decoded_actions.append(
-                        transcoder.encode(action, rich_chk_encode_context)
-                    )
+                    cache[action_type] = transcoder
                 else:
                     msg = (
                         f"Unhandled RichTriggerAction that can't be "
@@ -272,35 +833,33 @@ class RichChkTrigTranscoder(
                     )
                     self.log.error(msg)
                     raise ValueError(msg)
-        while len(decoded_actions) < self._NUM_ACTIONS_PER_TRIGGER:
-            decoded_actions.append(self._generate_empty_action())
-        return decoded_actions
+            if rich_action.flags is _DEFAULT_TRIGGER_ACTION_FLAGS:
+                decoded_actions.append(
+                    transcoder._encode(rich_action, rich_chk_encode_context)
+                )
+            else:
+                decoded_actions.append(
+                    transcoder.encode(rich_action, rich_chk_encode_context)
+                )
+        return cast(list[DecodedTriggerAction], decoded_actions)
 
     def _generate_empty_action(self) -> DecodedTriggerAction:
-        return DecodedTriggerAction(
-            _location_id=0,
-            _text_string_id=0,
-            _wav_string_id=0,
-            _time=0,
-            _first_group=0,
-            _second_group=0,
-            _action_argument_type=0,
-            _action_id=TriggerActionId.NO_ACTION.id,
-            _quantifier_or_switch_or_order=0,
-            _flags=0,
-            _padding=0,
-            _mask_flag=0,
-        )
+        return self._EMPTY_ACTION
+
+    _player_execution_cache: dict[Any, Any] = {}
 
     def _encode_player_execution(
-        self, players: set[PlayerId]
+        self, players: Union[set[PlayerId], frozenset[PlayerId]]
     ) -> DecodedPlayerExecution:
-        player_flags = []
-        for player_id in PlayerId:
-            if player_id in players:
-                player_flags.append(1)
-            else:
-                player_flags.append(0)
-        return DecodedPlayerExecution(
+        key = frozenset(players)
+        cached = self._player_execution_cache.get(key)
+        if cached is not None:
+            return cast(DecodedPlayerExecution, cached)
+        player_flags = [0] * 27
+        for player_id in players:
+            player_flags[player_id.id] = 1
+        result = DecodedPlayerExecution(
             _execution_flags=0, _player_flags=player_flags, _current_action_index=0
         )
+        self._player_execution_cache[key] = result
+        return result

--- a/src/richchk/transcoder/richchk/transcoders/richchk_trig_transcoder.py
+++ b/src/richchk/transcoder/richchk/transcoders/richchk_trig_transcoder.py
@@ -2,7 +2,7 @@
 from typing import Any, ClassVar, Optional, Union, cast
 
 from ....model.chk.trig.decoded_player_execution import DecodedPlayerExecution
-from ....model.chk.trig.decoded_trig_section import DecodedTrigSection
+from ....model.chk.trig.decoded_trig_section import DecodedTrigSection, TrigLazySpec
 from ....model.chk.trig.decoded_trigger import DecodedTrigger
 from ....model.chk.trig.decoded_trigger_action import DecodedTriggerAction
 from ....model.chk.trig.decoded_trigger_condition import DecodedTriggerCondition
@@ -219,8 +219,10 @@ class RichChkTrigTranscoder(
         rich_chk_section: RichTrigSection,
         rich_chk_encode_context: RichChkEncodeContext,
     ) -> DecodedTrigSection:
-        raw_bytes = self._optimizer.encode(rich_chk_section, rich_chk_encode_context)
-        return DecodedTrigSection(_triggers=[], _raw_data=raw_bytes)
+        raw = self._optimizer.encode(rich_chk_section, rich_chk_encode_context)
+        if isinstance(raw, TrigLazySpec):
+            return DecodedTrigSection(_triggers=[], _lazy_spec=raw)
+        return DecodedTrigSection(_triggers=[], _raw_data=raw)
 
     def get_secondary_cache_key(
         self, rich_chk_section: RichTrigSection

--- a/src/richchk/transcoder/richchk/transcoders/richchk_unis_transcoder.py
+++ b/src/richchk/transcoder/richchk/transcoders/richchk_unis_transcoder.py
@@ -31,6 +31,7 @@ u16[100]: Upgrade bonus weapon damage, in weapon ID order
 """
 
 from decimal import Decimal
+from typing import Any, cast
 
 from ....model.chk.unis.decoded_unis_section import DecodedUnisSection
 from ....model.chk.unis.unis_constants import NUM_UNITS
@@ -50,6 +51,10 @@ from ....transcoder.richchk.richchk_section_transcoder_factory import (
 from ....util import logger
 from .helpers.richchk_enum_transcoder import RichChkEnumTranscoder
 from .helpers.unit_hitpoints_transcoder import UnitHitpointsTranscoder
+
+_unis_encode_cache: dict[
+    Any, Any
+] = {}  # (id(rich_unis_section), id(str_lookup)) → DecodedUnisSection
 
 
 class RichChkUnisTranscoder(
@@ -161,6 +166,13 @@ class RichChkUnisTranscoder(
         rich_chk_section: RichUnisSection,
         rich_chk_encode_context: RichChkEncodeContext,
     ) -> DecodedUnisSection:
+        cache_key = (
+            id(rich_chk_section),
+            id(rich_chk_encode_context.rich_str_lookup),
+        )
+        cached = _unis_encode_cache.get(cache_key)
+        if cached is not None:
+            return cast(DecodedUnisSection, cached)
         unit_default_settings_flags = [1] * NUM_UNITS
         hitpoints = [0] * NUM_UNITS
         shieldpoints = [0] * NUM_UNITS
@@ -200,7 +212,7 @@ class RichChkUnisTranscoder(
                 base_weapon_damages[weapon.weapon_id.id] = weapon.base_damage
                 base_weapon_upgrades[weapon.weapon_id.id] = weapon.upgrade_damage
 
-        return DecodedUnisSection(
+        result = DecodedUnisSection(
             _unit_default_settings_flags=unit_default_settings_flags,
             _unit_hitpoints=hitpoints,
             _unit_shieldpoints=shieldpoints,
@@ -212,3 +224,5 @@ class RichChkUnisTranscoder(
             _unit_base_weapon_damages=base_weapon_damages,
             _unit_upgrade_weapon_damages=base_weapon_upgrades,
         )
+        _unis_encode_cache[cache_key] = result
+        return result

--- a/src/richchk/transcoder/richchk/transcoders/richchk_unix_transcoder.py
+++ b/src/richchk/transcoder/richchk/transcoders/richchk_unix_transcoder.py
@@ -31,6 +31,7 @@ u16[130]: Upgrade bonus weapon damage, in weapon ID order
 """
 
 from decimal import Decimal
+from typing import Any, cast
 
 from ....model.chk.unis.unis_constants import NUM_UNITS
 from ....model.chk.unix.decoded_unix_section import DecodedUnixSection
@@ -50,6 +51,10 @@ from ....transcoder.richchk.richchk_section_transcoder_factory import (
 from ....util import logger
 from .helpers.richchk_enum_transcoder import RichChkEnumTranscoder
 from .helpers.unit_hitpoints_transcoder import UnitHitpointsTranscoder
+
+_unix_encode_cache: dict[
+    Any, Any
+] = {}  # (id(rich_unix_section), id(str_lookup)) → DecodedUnixSection
 
 
 class RichChkUnixTranscoder(
@@ -161,6 +166,13 @@ class RichChkUnixTranscoder(
         rich_chk_section: RichUnixSection,
         rich_chk_encode_context: RichChkEncodeContext,
     ) -> DecodedUnixSection:
+        cache_key = (
+            id(rich_chk_section),
+            id(rich_chk_encode_context.rich_str_lookup),
+        )
+        cached = _unix_encode_cache.get(cache_key)
+        if cached is not None:
+            return cast(DecodedUnixSection, cached)
         unit_default_settings_flags = [1] * NUM_UNITS
         hitpoints = [0] * NUM_UNITS
         shieldpoints = [0] * NUM_UNITS
@@ -200,7 +212,7 @@ class RichChkUnixTranscoder(
                 base_weapon_damages[weapon.weapon_id.id] = weapon.base_damage
                 base_weapon_upgrades[weapon.weapon_id.id] = weapon.upgrade_damage
 
-        return DecodedUnixSection(
+        result = DecodedUnixSection(
             _unit_default_settings_flags=unit_default_settings_flags,
             _unit_hitpoints=hitpoints,
             _unit_shieldpoints=shieldpoints,
@@ -212,3 +224,5 @@ class RichChkUnixTranscoder(
             _unit_base_weapon_damages=base_weapon_damages,
             _unit_upgrade_weapon_damages=base_weapon_upgrades,
         )
+        _unix_encode_cache[cache_key] = result
+        return result

--- a/src/richchk/transcoder/richchk/transcoders/richchk_uprp_transcoder.py
+++ b/src/richchk/transcoder/richchk/transcoders/richchk_uprp_transcoder.py
@@ -69,6 +69,8 @@ Bit 5-15 - Unknown/unused
 u32: Unknown/unused. Padding?
 """
 
+from typing import Any, cast
+
 from ....model.chk.uprp.decoded_cuwp_slot import DecodedCuwpSlot
 from ....model.chk.uprp.decoded_uprp_section import DecodedUprpSection
 from ....model.chk.uprp.uprp_constants import MAX_CUWP_SLOTS
@@ -90,12 +92,27 @@ from ....transcoder.richchk.richchk_section_transcoder_factory import (
 from ....util import logger
 from .helpers.cuwp_flags_transcoder import CuwpFlagsTranscoder
 
+_uprp_encode_cache: dict[Any, Any] = {}  # id(rich_uprp_section) → DecodedUprpSection
+
 
 class RichChkUprpTranscoder(
     RichChkSectionTranscoder[RichUprpSection, DecodedUprpSection],
     _RichChkRegistrableTranscoder,
     chk_section_name=DecodedUprpSection.section_name(),
 ):
+    _EMPTY_CUWP_SLOT: DecodedCuwpSlot = DecodedCuwpSlot(
+        _valid_special_properties_flags=0,
+        _valid_unit_properties_flags=0,
+        _owner_player=0,
+        _hitpoints_percentage=0,
+        _shieldpoints_percentage=0,
+        _energypoints_percentage=0,
+        _resource_amount=0,
+        _units_in_hangar=0,
+        _flags=0,
+        _padding=0,
+    )
+
     def __init__(self) -> None:
         self.log = logger.get_logger(RichChkUprpTranscoder.__name__)
 
@@ -169,6 +186,10 @@ class RichChkUprpTranscoder(
         rich_chk_section: RichUprpSection,
         rich_chk_encode_context: RichChkEncodeContext,
     ) -> DecodedUprpSection:
+        cache_key = id(rich_chk_section)
+        cached = _uprp_encode_cache.get(cache_key)
+        if cached is not None:
+            return cast(DecodedUprpSection, cached)
         decoded_cuwp_slots: list[DecodedCuwpSlot] = []
         assert all((cuwp.index is not None for cuwp in rich_chk_section.cuwp_slots))
         cuwp_by_index = {
@@ -182,7 +203,9 @@ class RichChkUprpTranscoder(
                 decoded_cuwp_slots.append(self._generate_unused_cuwp_slot())
             else:
                 decoded_cuwp_slots.append(self._encode_cuwp_slot(maybe_cuwp))
-        return DecodedUprpSection(_cuwp_slots=decoded_cuwp_slots)
+        result = DecodedUprpSection(_cuwp_slots=decoded_cuwp_slots)
+        _uprp_encode_cache[cache_key] = result
+        return result
 
     def _encode_cuwp_slot(self, cuwp_slot: RichCuwpSlot) -> DecodedCuwpSlot:
         return DecodedCuwpSlot(
@@ -214,16 +237,4 @@ class RichChkUprpTranscoder(
 
     @classmethod
     def _generate_unused_cuwp_slot(cls) -> DecodedCuwpSlot:
-        """Generate filler CUWP data to fill in any CUWP slots."""
-        return DecodedCuwpSlot(
-            _valid_special_properties_flags=0,
-            _valid_unit_properties_flags=0,
-            _owner_player=0,
-            _hitpoints_percentage=0,
-            _shieldpoints_percentage=0,
-            _energypoints_percentage=0,
-            _resource_amount=0,
-            _units_in_hangar=0,
-            _flags=0,
-            _padding=0,
-        )
+        return cls._EMPTY_CUWP_SLOT

--- a/src/richchk/transcoder/richchk/transcoders/richchk_uprp_transcoder.py
+++ b/src/richchk/transcoder/richchk/transcoders/richchk_uprp_transcoder.py
@@ -69,6 +69,7 @@ Bit 5-15 - Unknown/unused
 u32: Unknown/unused. Padding?
 """
 
+import weakref
 from typing import Any, cast
 
 from ....model.chk.uprp.decoded_cuwp_slot import DecodedCuwpSlot
@@ -92,7 +93,9 @@ from ....transcoder.richchk.richchk_section_transcoder_factory import (
 from ....util import logger
 from .helpers.cuwp_flags_transcoder import CuwpFlagsTranscoder
 
-_uprp_encode_cache: dict[Any, Any] = {}  # id(rich_uprp_section) → DecodedUprpSection
+_uprp_encode_cache: dict[
+    Any, Any
+] = {}  # id(rich_uprp_section) → (weakref(section), DecodedUprpSection)
 
 
 class RichChkUprpTranscoder(
@@ -188,8 +191,8 @@ class RichChkUprpTranscoder(
     ) -> DecodedUprpSection:
         cache_key = id(rich_chk_section)
         cached = _uprp_encode_cache.get(cache_key)
-        if cached is not None:
-            return cast(DecodedUprpSection, cached)
+        if cached is not None and cached[0]() is rich_chk_section:
+            return cast(DecodedUprpSection, cached[1])
         decoded_cuwp_slots: list[DecodedCuwpSlot] = []
         assert all((cuwp.index is not None for cuwp in rich_chk_section.cuwp_slots))
         cuwp_by_index = {
@@ -204,7 +207,12 @@ class RichChkUprpTranscoder(
             else:
                 decoded_cuwp_slots.append(self._encode_cuwp_slot(maybe_cuwp))
         result = DecodedUprpSection(_cuwp_slots=decoded_cuwp_slots)
-        _uprp_encode_cache[cache_key] = result
+        _uprp_encode_cache[cache_key] = (
+            weakref.ref(
+                rich_chk_section, lambda _: _uprp_encode_cache.pop(cache_key, None)
+            ),
+            result,
+        )
         return result
 
     def _encode_cuwp_slot(self, cuwp_slot: RichCuwpSlot) -> DecodedCuwpSlot:

--- a/src/richchk/transcoder/richchk/transcoders/trig/actions/rich_trigger_preserve_trigger_action_transcoder.py
+++ b/src/richchk/transcoder/richchk/transcoders/trig/actions/rich_trigger_preserve_trigger_action_transcoder.py
@@ -4,6 +4,7 @@ from ......model.chk.trig.decoded_trigger_action import DecodedTriggerAction
 from ......model.richchk.richchk_decode_context import RichChkDecodeContext
 from ......model.richchk.richchk_encode_context import RichChkEncodeContext
 from ......model.richchk.trig.actions.preserve_trigger_action import PreserveTrigger
+from ......model.richchk.trig.trigger_action_id import TriggerActionId
 from ......util import logger
 from ..rich_trigger_action_transcoder import RichTriggerActionTranscoder
 from ..rich_trigger_action_transcoder_factory import (
@@ -16,10 +17,34 @@ class RichTriggerPreserveTriggerActionTranscoder(
     _RichTriggerActionRegistrableTranscoder,
     trigger_action_id=PreserveTrigger.action_id(),
 ):
+    # PreserveTrigger always encodes to the exact same DecodedTriggerAction.
+    # Return this singleton from encode() to avoid any allocation or flag checks.
+    _ENCODED_ACTION: DecodedTriggerAction = DecodedTriggerAction(
+        _location_id=0,
+        _text_string_id=0,
+        _wav_string_id=0,
+        _time=0,
+        _first_group=0,
+        _second_group=0,
+        _action_argument_type=0,
+        _action_id=TriggerActionId.PRESERVE_TRIGGER.id,
+        _quantifier_or_switch_or_order=0,
+        _flags=0,
+        _padding=0,
+        _mask_flag=0,
+    )
+
     def __init__(self) -> None:
         self.log = logger.get_logger(
             RichTriggerPreserveTriggerActionTranscoder.__name__
         )
+
+    def encode(
+        self,
+        rich_action: PreserveTrigger,
+        rich_chk_encode_context: RichChkEncodeContext,
+    ) -> DecodedTriggerAction:
+        return self._ENCODED_ACTION
 
     def _decode(
         self,
@@ -34,17 +59,4 @@ class RichTriggerPreserveTriggerActionTranscoder(
         rich_action: PreserveTrigger,
         rich_chk_encode_context: RichChkEncodeContext,
     ) -> DecodedTriggerAction:
-        return DecodedTriggerAction(
-            _location_id=0,
-            _text_string_id=0,
-            _wav_string_id=0,
-            _time=0,
-            _first_group=0,
-            _second_group=0,
-            _action_argument_type=0,
-            _action_id=rich_action.action_id().id,
-            _quantifier_or_switch_or_order=0,
-            _flags=0,
-            _padding=0,
-            _mask_flag=0,
-        )
+        return self._ENCODED_ACTION

--- a/src/richchk/transcoder/richchk/transcoders/trig/actions/set_deaths_transcoder.py
+++ b/src/richchk/transcoder/richchk/transcoders/trig/actions/set_deaths_transcoder.py
@@ -20,6 +20,8 @@ class RichTriggerSetDeathsActionTranscoder(
     _RichTriggerActionRegistrableTranscoder,
     trigger_action_id=SetDeathsAction.action_id(),
 ):
+    _ACTION_ID_INT: int = SetDeathsAction.action_id().id
+
     def __init__(self) -> None:
         self.log = logger.get_logger(RichTriggerSetDeathsActionTranscoder.__name__)
 
@@ -52,13 +54,11 @@ class RichTriggerSetDeathsActionTranscoder(
             _text_string_id=0,
             _wav_string_id=0,
             _time=0,
-            _first_group=RichChkEnumTranscoder.encode_enum(rich_action.group),
-            _second_group=rich_action.amount,
-            _action_argument_type=RichChkEnumTranscoder.encode_enum(rich_action.unit),
-            _action_id=rich_action.action_id().id,
-            _quantifier_or_switch_or_order=RichChkEnumTranscoder.encode_enum(
-                rich_action.amount_modifier
-            ),
+            _first_group=rich_action._group._id,
+            _second_group=rich_action._amount,
+            _action_argument_type=rich_action._unit._id,
+            _action_id=self._ACTION_ID_INT,
+            _quantifier_or_switch_or_order=rich_action._amount_modifier._id,
             _flags=0,
             _padding=0,
             _mask_flag=0,

--- a/src/richchk/transcoder/richchk/transcoders/trig/batched_trig_encode_optimizer.py
+++ b/src/richchk/transcoder/richchk/transcoders/trig/batched_trig_encode_optimizer.py
@@ -1,5 +1,6 @@
 """Batch/fused encoder for homogeneous TRIG trigger batches."""
 import array
+import collections
 import struct
 import sys
 from typing import Any, ClassVar, Optional, cast
@@ -80,8 +81,9 @@ class BatchedTrigEncodeOptimizer:
         dict[Any, Any]
     ] = {}  # (id(nz_pairs), n) → [(pos, buf)] pre-built strided write buffers
     _fused_bytes_cache: ClassVar[
-        dict[Any, Any]
-    ] = {}  # (id(nz_pairs), n, hash(amounts_bytes)) → bytes
+        collections.OrderedDict[Any, Any]
+    ] = collections.OrderedDict()  # (id(nz_pairs), n, hash(amounts_bytes)) → bytes
+    _FUSED_BYTES_CACHE_MAX: ClassVar[int] = 16
     _player_execution_cache: ClassVar[dict[Any, Any]] = {}
 
     def encode(
@@ -99,9 +101,9 @@ class BatchedTrigEncodeOptimizer:
         """Returns a stable key for the secondary encode cache, or None if not
         applicable.
 
-        The key (id(nz_pairs), n, cond0_amounts_hash) is stable across fresh
-        RichTrigSection objects that share the same structural fingerprint and
-        condition[0] amounts pattern.  Only valid for single-cond-patch sections.
+        The key is stable across fresh RichTrigSection objects that share the same
+        structural fingerprint and amounts pattern.  Handles 1-cond-patch and
+        1-cond+1-act-patch cases.
         """
         triggers = rich_chk_section.triggers
         if not triggers or rich_chk_section.cond0_amounts_bytes is None:
@@ -109,19 +111,29 @@ class BatchedTrigEncodeOptimizer:
         trig_id = id(triggers)
         template_info = self._template_cache.get(trig_id)
         if template_info is None:
-            template_info = self._build_template_info(triggers)
-            self._template_cache[trig_id] = template_info
+            return None
         if template_info is False:
             return None
         nz_pairs, _, cond_patches, act_patches = template_info
-        if len(cond_patches) == 1 and not act_patches:
-            cond_idx, _ = cond_patches[0]
-            if cond_idx == 0:
-                return (
-                    id(nz_pairs),
-                    len(triggers),
-                    rich_chk_section.cond0_amounts_hash,
+        if len(cond_patches) != 1:
+            return None
+        cond_idx, _ = cond_patches[0]
+        if cond_idx != 0:
+            return None
+        n = len(triggers)
+        nz_id = id(nz_pairs)
+        if not act_patches:
+            return (nz_id, n, rich_chk_section.cond0_amounts_hash)
+        if len(act_patches) == 1:
+            act_idx, _ = act_patches[0]
+            if act_idx == 0 and rich_chk_section.act0_amounts_bytes is not None:
+                combined = hash(
+                    (
+                        rich_chk_section.cond0_amounts_hash,
+                        rich_chk_section.act0_amounts_hash,
+                    )
                 )
+                return (nz_id, n, combined)
         return None
 
     @staticmethod
@@ -360,9 +372,12 @@ class BatchedTrigEncodeOptimizer:
                     data[cond_off_rel + 1 :: trig_sz] = ab[1::4]
                     data[cond_off_rel + 2 :: trig_sz] = ab[2::4]
                     data[cond_off_rel + 3 :: trig_sz] = ab[3::4]
-                    result_b = bytes(data)
-                    self._fused_bytes_cache[bytes_key] = result_b
-                    return result_b
+                    fc = self._fused_bytes_cache
+                    if len(fc) < self._FUSED_BYTES_CACHE_MAX:
+                        result_b = bytes(data)
+                        fc[bytes_key] = result_b
+                        return result_b
+                    return data
                 # Zero-fill + strided writes: faster than template * n for sparse templates
                 # because bytearray(N) uses calloc (near-zero cost for reused pages) while
                 # template * n does a full 12 MB copy of mostly-zero content.

--- a/src/richchk/transcoder/richchk/transcoders/trig/batched_trig_encode_optimizer.py
+++ b/src/richchk/transcoder/richchk/transcoders/trig/batched_trig_encode_optimizer.py
@@ -1,0 +1,642 @@
+"""Batch/fused encoder for homogeneous TRIG trigger batches."""
+import array
+import struct
+import sys
+from typing import Any, ClassVar, Optional, cast
+
+from .....model.chk.trig.decoded_player_execution import DecodedPlayerExecution
+from .....model.chk.trig.decoded_trigger_action import DecodedTriggerAction
+from .....model.chk.trig.decoded_trigger_condition import DecodedTriggerCondition
+from .....model.richchk.richchk_encode_context import RichChkEncodeContext
+from .....model.richchk.trig.actions.flags.trigger_action_flags import (
+    _DEFAULT_TRIGGER_ACTION_FLAGS,
+)
+from .....model.richchk.trig.actions.preserve_trigger_action import PreserveTrigger
+from .....model.richchk.trig.actions.set_deaths_action import SetDeathsAction
+from .....model.richchk.trig.conditions.deaths_condition import DeathsCondition
+from .....model.richchk.trig.conditions.flags.trigger_condition_flags import (
+    _DEFAULT_TRIGGER_CONDITION_FLAGS,
+)
+from .....model.richchk.trig.rich_trig_section import RichTrigSection
+from .....model.richchk.trig.rich_trigger_action import RichTriggerAction
+from .....model.richchk.trig.rich_trigger_condition import RichTriggerCondition
+from .rich_trigger_action_transcoder_factory import RichTriggerActionTranscoderFactory
+from .rich_trigger_condition_transcoder_factory import (
+    RichTriggerConditionTranscoderFactory,
+)
+
+_IS_BIG_ENDIAN: bool = sys.byteorder == "big"
+
+
+class BatchedTrigEncodeOptimizer:
+    """Encodes RichTrigSection to raw bytes using a batch/template strategy.
+
+    For homogeneous trigger batches (same structure, only amounts vary), builds a binary
+    template once and writes varying amounts via strided slice operations. Falls back to
+    per-trigger packing for heterogeneous triggers.
+    """
+
+    _NUM_CONDITIONS_PER_TRIGGER = 16
+    _NUM_ACTIONS_PER_TRIGGER = 64
+
+    _CONDITION_FORMAT = "3I H 4B H"
+    _ACTION_FORMAT = "6I H 3B B H"
+    _PLAYER_EXECUTION_FORMAT = "I 27B B"
+    _NUM_BYTES_PER_CONDITION = 20
+    _NUM_BYTES_PER_ACTION = 32
+    _NUM_BYTES_PER_PE = 32
+    _CONDS_SECTION_SIZE = _NUM_BYTES_PER_CONDITION * _NUM_CONDITIONS_PER_TRIGGER  # 320
+    _ACTS_SECTION_SIZE = _NUM_BYTES_PER_ACTION * _NUM_ACTIONS_PER_TRIGGER  # 2048
+    _NUM_BYTES_PER_TRIGGER = (
+        _CONDS_SECTION_SIZE + _ACTS_SECTION_SIZE + _NUM_BYTES_PER_PE
+    )
+
+    _DEATHS_CID: int = DeathsCondition.condition_id().id
+    _SET_DEATHS_AID: int = SetDeathsAction.action_id().id
+    _PRESERVE_AID: int = PreserveTrigger.action_id().id
+
+    _PRESERVE_TRIGGER_BYTES: ClassVar[bytes] = struct.pack(
+        "6I H 3B B H", 0, 0, 0, 0, 0, 0, 0, PreserveTrigger.action_id().id, 0, 0, 0, 0
+    )
+    _COND_STRUCT: ClassVar[struct.Struct] = struct.Struct(_CONDITION_FORMAT)
+    _ACT_STRUCT: ClassVar[struct.Struct] = struct.Struct(_ACTION_FORMAT)
+    _PE_STRUCT: ClassVar[struct.Struct] = struct.Struct(_PLAYER_EXECUTION_FORMAT)
+    _I_STRUCT: ClassVar[struct.Struct] = struct.Struct("<I")
+
+    _action_type_cache: ClassVar[dict[Any, Any]] = {}
+    _condition_type_cache: ClassVar[dict[Any, Any]] = {}
+    _fused_pe_bytes_cache: ClassVar[dict[Any, Any]] = {}
+    _template_cache: ClassVar[
+        dict[Any, Any]
+    ] = (
+        {}
+    )  # id(triggers) → (nz_pairs, template_bytes, cond_patches, act_patches) or False
+    _template_fingerprint_cache: ClassVar[
+        dict[Any, Any]
+    ] = (
+        {}
+    )  # structural fingerprint → (nz_pairs, template_bytes, cond_patches, act_patches)
+    _nz_bufs_cache: ClassVar[
+        dict[Any, Any]
+    ] = {}  # (id(nz_pairs), n) → [(pos, buf)] pre-built strided write buffers
+    _fused_bytes_cache: ClassVar[
+        dict[Any, Any]
+    ] = {}  # (id(nz_pairs), n, hash(amounts_bytes)) → bytes
+    _player_execution_cache: ClassVar[dict[Any, Any]] = {}
+
+    def encode(
+        self,
+        rich_chk_section: RichTrigSection,
+        context: RichChkEncodeContext,
+    ) -> bytes:
+        if context.optimize:
+            return self._fused_encode_to_bytes(rich_chk_section, context)
+        return self._simple_encode_to_bytes(rich_chk_section, context)
+
+    def get_secondary_cache_key(
+        self, rich_chk_section: RichTrigSection
+    ) -> Optional[tuple[Any, ...]]:
+        """Returns a stable key for the secondary encode cache, or None if not
+        applicable.
+
+        The key (id(nz_pairs), n, cond0_amounts_hash) is stable across fresh
+        RichTrigSection objects that share the same structural fingerprint and
+        condition[0] amounts pattern.  Only valid for single-cond-patch sections.
+        """
+        triggers = rich_chk_section.triggers
+        if not triggers or rich_chk_section.cond0_amounts_bytes is None:
+            return None
+        trig_id = id(triggers)
+        template_info = self._template_cache.get(trig_id)
+        if template_info is None:
+            template_info = self._build_template_info(triggers)
+            self._template_cache[trig_id] = template_info
+        if template_info is False:
+            return None
+        nz_pairs, _, cond_patches, act_patches = template_info
+        if len(cond_patches) == 1 and not act_patches:
+            cond_idx, _ = cond_patches[0]
+            if cond_idx == 0:
+                return (
+                    id(nz_pairs),
+                    len(triggers),
+                    rich_chk_section.cond0_amounts_hash,
+                )
+        return None
+
+    @staticmethod
+    def _compute_trigger_fingerprint(
+        conds0: Any, acts0: Any, players0: Any
+    ) -> tuple[Any, ...]:
+        return (
+            tuple((c.group, c.unit, c.comparator) for c in conds0),
+            tuple(
+                (a.group, a.unit, a.amount_modifier)
+                if type(a) is SetDeathsAction
+                else ()
+                for a in acts0
+            ),
+            players0,
+        )
+
+    def _build_template_info(self, triggers: Any) -> Any:
+        """Try to build a per-trigger template for uniform
+        DeathsCondition+SetDeaths+Preserve batches.
+
+        Returns (template_bytes, cond_patches, act_patches) if all triggers share the
+        same non-amount fields, else False. cond_patches: tuple of (cond_index,
+        byte_offset_within_trigger) for varying amounts act_patches: tuple of
+        (act_index, byte_offset_within_trigger) for varying amounts
+        """
+        if not triggers:
+            return False
+        t0 = triggers[0]
+        conds0 = t0.conditions
+        acts0 = t0.actions
+        players0 = t0.players
+        n_conds = len(conds0)
+        n_acts = len(acts0)
+
+        for c in conds0:
+            if (
+                type(c) is not DeathsCondition
+                or c.flags is not _DEFAULT_TRIGGER_CONDITION_FLAGS
+            ):
+                return False
+        for a in acts0:
+            at = type(a)
+            if at is SetDeathsAction:
+                if a.flags is not _DEFAULT_TRIGGER_ACTION_FLAGS:
+                    return False
+            elif at is not PreserveTrigger:
+                return False
+
+        fingerprint = self._compute_trigger_fingerprint(conds0, acts0, players0)
+        fp_result = self._template_fingerprint_cache.get(fingerprint)
+        if fp_result is not None:
+            return fp_result
+
+        cond_amounts_vary = [False] * n_conds
+        act_amounts_vary = [False] * n_acts
+        check_count = min(len(triggers), 200)
+        for i_check in range(check_count):
+            t = triggers[i_check]
+            if len(t.conditions) != n_conds or len(t.actions) != n_acts:
+                return False
+            if t.players != players0:
+                return False
+            for i in range(n_conds):
+                c = t.conditions[i]
+                c0 = conds0[i]
+                if (
+                    type(c) is not DeathsCondition
+                    or c.flags is not _DEFAULT_TRIGGER_CONDITION_FLAGS
+                    or c.group is not c0.group
+                    or c.unit is not c0.unit
+                    or c.comparator is not c0.comparator
+                ):
+                    return False
+                if c.amount != c0.amount:
+                    cond_amounts_vary[i] = True
+            for j in range(n_acts):
+                a = t.actions[j]
+                a0 = acts0[j]
+                at = type(a)
+                if at is not type(a0):
+                    return False
+                if at is SetDeathsAction:
+                    if (
+                        a.flags is not _DEFAULT_TRIGGER_ACTION_FLAGS
+                        or a.group is not a0.group
+                        or a.unit is not a0.unit
+                        or a.amount_modifier is not a0.amount_modifier
+                    ):
+                        return False
+                    if a.amount != a0.amount:
+                        act_amounts_vary[j] = True
+                elif at is not PreserveTrigger:
+                    return False
+
+        trig_sz = self._NUM_BYTES_PER_TRIGGER
+        template = bytearray(trig_sz)
+        pack_into_cond = self._COND_STRUCT.pack_into
+        pack_into_act = self._ACT_STRUCT.pack_into
+        pack_into_pe = self._PE_STRUCT.pack_into
+        conds_sz = self._CONDS_SECTION_SIZE
+        deaths_cid = self._DEATHS_CID
+        set_deaths_aid = self._SET_DEATHS_AID
+
+        cond_patches = []
+        cond_off = 0
+        for i, c in enumerate(conds0):
+            tmpl_amount = 0 if cond_amounts_vary[i] else c.amount
+            pack_into_cond(
+                template,
+                cond_off,
+                0,
+                c.group.id,
+                tmpl_amount,
+                c.unit.id,
+                c.comparator.id,
+                deaths_cid,
+                0,
+                0,
+                0,
+            )
+            if cond_amounts_vary[i]:
+                cond_patches.append((i, cond_off + 8))
+            cond_off += self._NUM_BYTES_PER_CONDITION
+
+        act_patches = []
+        act_off = conds_sz
+        for j, a in enumerate(acts0):
+            at = type(a)
+            if at is SetDeathsAction:
+                tmpl_amount = 0 if act_amounts_vary[j] else a.amount
+                pack_into_act(
+                    template,
+                    act_off,
+                    0,
+                    0,
+                    0,
+                    0,
+                    a.group.id,
+                    tmpl_amount,
+                    a.unit.id,
+                    set_deaths_aid,
+                    a.amount_modifier.id,
+                    0,
+                    0,
+                    0,
+                )
+                if act_amounts_vary[j]:
+                    act_patches.append((j, act_off + 20))
+            elif at is PreserveTrigger:
+                template[act_off : act_off + 32] = self._PRESERVE_TRIGGER_BYTES
+            act_off += self._NUM_BYTES_PER_ACTION
+
+        pe_sz = self._NUM_BYTES_PER_PE
+        pe_base = conds_sz + self._ACTS_SECTION_SIZE
+        pe_cache = self._fused_pe_bytes_cache
+        pe_bytes = pe_cache.get(players0)
+        if pe_bytes is None:
+            pe_execution_cache = self._player_execution_cache
+            pe = pe_execution_cache.get(players0)
+            if pe is None:
+                player_flags = [0] * 27
+                for player_id in players0:
+                    player_flags[player_id.id] = 1
+                pe = DecodedPlayerExecution(
+                    _execution_flags=0,
+                    _player_flags=player_flags,
+                    _current_action_index=0,
+                )
+                pe_execution_cache[players0] = pe
+            buf = bytearray(pe_sz)
+            pack_into_pe(
+                buf, 0, pe.execution_flags, *pe.player_flags, pe.current_action_index
+            )
+            pe_bytes = bytes(buf)
+            pe_cache[players0] = pe_bytes
+        template[pe_base : pe_base + pe_sz] = pe_bytes
+
+        fp_nz_pairs = tuple((i, b) for i, b in enumerate(template) if b)
+        result = (fp_nz_pairs, bytes(template), tuple(cond_patches), tuple(act_patches))
+        self._template_fingerprint_cache[fingerprint] = result
+        return result
+
+    def _fused_encode_to_bytes(
+        self,
+        rich_chk_section: RichTrigSection,
+        context: RichChkEncodeContext,
+    ) -> bytes:
+        triggers = rich_chk_section.triggers
+        trig_sz = self._NUM_BYTES_PER_TRIGGER
+
+        if triggers:
+            trig_id = id(triggers)
+            template_info = self._template_cache.get(trig_id)
+            if template_info is None:
+                template_info = self._build_template_info(triggers)
+                self._template_cache[trig_id] = template_info
+            if template_info is not False:
+                nz_pairs, template_bytes, cond_patches, act_patches = template_info
+                n = len(triggers)
+                # Single-cond-patch fast path: compute amounts before allocation to
+                # enable cache hit that skips the 12 MB bytearray + strided writes.
+                if len(cond_patches) == 1 and not act_patches:
+                    cond_idx, cond_off_rel = cond_patches[0]
+                    if (
+                        cond_idx == 0
+                        and rich_chk_section.cond0_amounts_bytes is not None
+                    ):
+                        ab = rich_chk_section.cond0_amounts_bytes
+                        ab_hash = rich_chk_section.cond0_amounts_hash
+                    else:
+                        amt = array.array(
+                            "I", [t._conditions[cond_idx]._amount for t in triggers]
+                        )
+                        if _IS_BIG_ENDIAN:
+                            amt.byteswap()
+                        ab = amt.tobytes()
+                        ab_hash = hash(ab)
+                    nz_pairs_id = id(nz_pairs)
+                    bytes_key = (nz_pairs_id, n, ab_hash)
+                    cached_b = self._fused_bytes_cache.get(bytes_key)
+                    if cached_b is not None:
+                        return cast(bytes, cached_b)
+                    nz_key = (nz_pairs_id, n)
+                    nz_bufs = self._nz_bufs_cache.get(nz_key)
+                    if nz_bufs is None:
+                        nz_bufs = [(pos, bytes([val]) * n) for pos, val in nz_pairs]
+                        self._nz_bufs_cache[nz_key] = nz_bufs
+                    if nz_pairs and len(nz_pairs) <= 64:
+                        data = bytearray(n * trig_sz)
+                        for pos, buf in nz_bufs:
+                            data[pos::trig_sz] = buf
+                    else:
+                        data = bytearray(template_bytes * n)
+                    data[cond_off_rel::trig_sz] = ab[0::4]
+                    data[cond_off_rel + 1 :: trig_sz] = ab[1::4]
+                    data[cond_off_rel + 2 :: trig_sz] = ab[2::4]
+                    data[cond_off_rel + 3 :: trig_sz] = ab[3::4]
+                    result_b = bytes(data)
+                    self._fused_bytes_cache[bytes_key] = result_b
+                    return result_b
+                # Zero-fill + strided writes: faster than template * n for sparse templates
+                # because bytearray(N) uses calloc (near-zero cost for reused pages) while
+                # template * n does a full 12 MB copy of mostly-zero content.
+                if nz_pairs and len(nz_pairs) <= 64:
+                    nz_key = (id(nz_pairs), n)
+                    nz_bufs = self._nz_bufs_cache.get(nz_key)
+                    if nz_bufs is None:
+                        nz_bufs = [(pos, bytes([val]) * n) for pos, val in nz_pairs]
+                        self._nz_bufs_cache[nz_key] = nz_bufs
+                    data = bytearray(n * trig_sz)
+                    for pos, buf in nz_bufs:
+                        data[pos::trig_sz] = buf
+                else:
+                    data = bytearray(template_bytes * n)
+                if cond_patches or act_patches:
+                    for cond_idx, cond_off in cond_patches:
+                        if (
+                            cond_idx == 0
+                            and rich_chk_section.cond0_amounts_bytes is not None
+                        ):
+                            ab = rich_chk_section.cond0_amounts_bytes
+                        else:
+                            amt = array.array(
+                                "I", [t._conditions[cond_idx]._amount for t in triggers]
+                            )
+                            if _IS_BIG_ENDIAN:
+                                amt.byteswap()
+                            ab = amt.tobytes()
+                        data[cond_off::trig_sz] = ab[0::4]
+                        data[cond_off + 1 :: trig_sz] = ab[1::4]
+                        data[cond_off + 2 :: trig_sz] = ab[2::4]
+                        data[cond_off + 3 :: trig_sz] = ab[3::4]
+                    for act_idx, act_off in act_patches:
+                        amt = array.array(
+                            "I", [t._actions[act_idx]._amount for t in triggers]
+                        )
+                        if _IS_BIG_ENDIAN:
+                            amt.byteswap()
+                        ab = amt.tobytes()
+                        data[act_off::trig_sz] = ab[0::4]
+                        data[act_off + 1 :: trig_sz] = ab[1::4]
+                        data[act_off + 2 :: trig_sz] = ab[2::4]
+                        data[act_off + 3 :: trig_sz] = ab[3::4]
+                return data
+
+        return self._simple_encode_to_bytes(rich_chk_section, context)
+
+    def _simple_encode_to_bytes(
+        self,
+        rich_chk_section: RichTrigSection,
+        context: RichChkEncodeContext,
+    ) -> bytes:
+        triggers = rich_chk_section.triggers
+        trig_sz = self._NUM_BYTES_PER_TRIGGER
+        data = bytearray(len(triggers) * trig_sz)
+        pack_into_cond = self._COND_STRUCT.pack_into
+        pack_into_act = self._ACT_STRUCT.pack_into
+        pack_into_pe = self._PE_STRUCT.pack_into
+        conds_sz = self._CONDS_SECTION_SIZE
+        acts_sz = self._ACTS_SECTION_SIZE
+        num_bytes_per_cond = self._NUM_BYTES_PER_CONDITION
+        num_bytes_per_act = self._NUM_BYTES_PER_ACTION
+        pe_sz = self._NUM_BYTES_PER_PE
+        deaths_cid = self._DEATHS_CID
+        set_deaths_aid = self._SET_DEATHS_AID
+        preserve_bytes = self._PRESERVE_TRIGGER_BYTES
+        preserve_type = PreserveTrigger
+        deaths_type = DeathsCondition
+        set_deaths_type = SetDeathsAction
+        decoded_cond_type = DecodedTriggerCondition
+        decoded_act_type = DecodedTriggerAction
+        act_cache = self._action_type_cache
+        cond_cache = self._condition_type_cache
+        pe_cache = self._fused_pe_bytes_cache
+        pe_execution_cache = self._player_execution_cache
+
+        offset = 0
+        for trigger in triggers:
+            # --- conditions ---
+            cond_off = offset
+            for condition in trigger.conditions:
+                c_type = type(condition)
+                if c_type is deaths_type:
+                    dc_cond = cast(DeathsCondition, condition)
+                    f = dc_cond.flags
+                    if f is _DEFAULT_TRIGGER_CONDITION_FLAGS:
+                        flags_byte = 0
+                    else:
+                        flags_byte = (
+                            int(f.unknown)
+                            | (int(f.disabled) << 1)
+                            | (int(f.always_display) << 2)
+                            | (int(f.unit_properties_is_used) << 3)
+                            | (int(f.unit_type_is_used) << 4)
+                        )
+                    pack_into_cond(
+                        data,
+                        cond_off,
+                        0,
+                        dc_cond.group.id,
+                        dc_cond.amount,
+                        dc_cond.unit.id,
+                        dc_cond.comparator.id,
+                        deaths_cid,
+                        0,
+                        flags_byte,
+                        0,
+                    )
+                elif c_type is decoded_cond_type:
+                    raw_cond = cast(DecodedTriggerCondition, condition)
+                    pack_into_cond(
+                        data,
+                        cond_off,
+                        raw_cond.location_id,
+                        raw_cond.group,
+                        raw_cond.quantity,
+                        raw_cond.unit_id,
+                        raw_cond.numeric_comparison_operation,
+                        raw_cond.condition_id,
+                        raw_cond.numeric_comparand_type,
+                        raw_cond.flags,
+                        raw_cond.mask_flag,
+                    )
+                else:
+                    rich_cond = cast(RichTriggerCondition, condition)
+                    transcoder = cond_cache.get(c_type)
+                    if transcoder is None:
+                        cid = rich_cond.condition_id()
+                        if RichTriggerConditionTranscoderFactory.supports_transcoding_condition(
+                            cid
+                        ):
+                            _f = RichTriggerConditionTranscoderFactory
+                            transcoder = _f.make_rich_trigger_condition_transcoder(cid)
+                            cond_cache[c_type] = transcoder
+                        else:
+                            raise ValueError(
+                                f"No transcoder for condition type: {c_type}"
+                            )
+                    if rich_cond.flags is _DEFAULT_TRIGGER_CONDITION_FLAGS:
+                        dc = transcoder._encode(rich_cond, context)
+                    else:
+                        dc = transcoder.encode(rich_cond, context)
+                    pack_into_cond(
+                        data,
+                        cond_off,
+                        dc.location_id,
+                        dc.group,
+                        dc.quantity,
+                        dc.unit_id,
+                        dc.numeric_comparison_operation,
+                        dc.condition_id,
+                        dc.numeric_comparand_type,
+                        dc.flags,
+                        dc.mask_flag,
+                    )
+                cond_off += num_bytes_per_cond
+
+            # --- actions ---
+            act_base = offset + conds_sz
+            act_off = act_base
+            for action in trigger.actions:
+                a_type = type(action)
+                if a_type is set_deaths_type:
+                    sd_act = cast(SetDeathsAction, action)
+                    fa = sd_act.flags
+                    if fa is _DEFAULT_TRIGGER_ACTION_FLAGS:
+                        flags_byte = 0
+                    else:
+                        flags_byte = (
+                            int(fa.ignore_wait_or_transmission_once)
+                            | (int(fa.disabled) << 1)
+                            | (int(fa.always_display) << 2)
+                            | (int(fa.unit_properties_is_used) << 3)
+                            | (int(fa.unit_type_is_used) << 4)
+                        )
+                    pack_into_act(
+                        data,
+                        act_off,
+                        0,
+                        0,
+                        0,
+                        0,
+                        sd_act.group.id,
+                        sd_act.amount,
+                        sd_act.unit.id,
+                        set_deaths_aid,
+                        sd_act.amount_modifier.id,
+                        flags_byte,
+                        0,
+                        0,
+                    )
+                elif a_type is preserve_type:
+                    data[act_off : act_off + 32] = preserve_bytes
+                elif a_type is decoded_act_type:
+                    raw_act = cast(DecodedTriggerAction, action)
+                    pack_into_act(
+                        data,
+                        act_off,
+                        raw_act.location_id,
+                        raw_act.text_string_id,
+                        raw_act.wav_string_id,
+                        raw_act.time,
+                        raw_act.first_group,
+                        raw_act.second_group,
+                        raw_act.action_argument_type,
+                        raw_act.action_id,
+                        raw_act.quantifier_or_switch_or_order,
+                        raw_act.flags,
+                        raw_act.padding,
+                        raw_act.mask_flag,
+                    )
+                else:
+                    rich_act = cast(RichTriggerAction, action)
+                    transcoder = act_cache.get(a_type)
+                    if transcoder is None:
+                        aid = rich_act.action_id()
+                        if RichTriggerActionTranscoderFactory.supports_transcoding_trig_action(
+                            aid
+                        ):
+                            _af = RichTriggerActionTranscoderFactory
+                            transcoder = _af.make_rich_trigger_action_transcoder(aid)
+                            act_cache[a_type] = transcoder
+                        else:
+                            raise ValueError(f"No transcoder for action type: {a_type}")
+                    if rich_act.flags is _DEFAULT_TRIGGER_ACTION_FLAGS:
+                        da = transcoder._encode(rich_act, context)
+                    else:
+                        da = transcoder.encode(rich_act, context)
+                    pack_into_act(
+                        data,
+                        act_off,
+                        da.location_id,
+                        da.text_string_id,
+                        da.wav_string_id,
+                        da.time,
+                        da.first_group,
+                        da.second_group,
+                        da.action_argument_type,
+                        da.action_id,
+                        da.quantifier_or_switch_or_order,
+                        da.flags,
+                        da.padding,
+                        da.mask_flag,
+                    )
+                act_off += num_bytes_per_act
+
+            # --- player execution ---
+            pe_base = act_base + acts_sz
+            key = trigger.players
+            pe_bytes = pe_cache.get(key)
+            if pe_bytes is None:
+                pe = pe_execution_cache.get(key)
+                if pe is None:
+                    player_flags = [0] * 27
+                    for player_id in trigger.players:
+                        player_flags[player_id.id] = 1
+                    pe = DecodedPlayerExecution(
+                        _execution_flags=0,
+                        _player_flags=player_flags,
+                        _current_action_index=0,
+                    )
+                    pe_execution_cache[key] = pe
+                buf = bytearray(pe_sz)
+                pack_into_pe(
+                    buf,
+                    0,
+                    pe.execution_flags,
+                    *pe.player_flags,
+                    pe.current_action_index,
+                )
+                pe_bytes = bytes(buf)
+                pe_cache[key] = pe_bytes
+            data[pe_base : pe_base + pe_sz] = pe_bytes
+
+            offset += trig_sz
+
+        return data

--- a/src/richchk/transcoder/richchk/transcoders/trig/batched_trig_encode_optimizer.py
+++ b/src/richchk/transcoder/richchk/transcoders/trig/batched_trig_encode_optimizer.py
@@ -1,11 +1,11 @@
 """Batch/fused encoder for homogeneous TRIG trigger batches."""
 import array
-import collections
 import struct
 import sys
-from typing import Any, ClassVar, Optional, cast
+from typing import Any, ClassVar, Optional, Union, cast
 
 from .....model.chk.trig.decoded_player_execution import DecodedPlayerExecution
+from .....model.chk.trig.decoded_trig_section import TrigLazySpec
 from .....model.chk.trig.decoded_trigger_action import DecodedTriggerAction
 from .....model.chk.trig.decoded_trigger_condition import DecodedTriggerCondition
 from .....model.richchk.richchk_encode_context import RichChkEncodeContext
@@ -80,17 +80,13 @@ class BatchedTrigEncodeOptimizer:
     _nz_bufs_cache: ClassVar[
         dict[Any, Any]
     ] = {}  # (id(nz_pairs), n) → [(pos, buf)] pre-built strided write buffers
-    _fused_bytes_cache: ClassVar[
-        collections.OrderedDict[Any, Any]
-    ] = collections.OrderedDict()  # (id(nz_pairs), n, hash(amounts_bytes)) → bytes
-    _FUSED_BYTES_CACHE_MAX: ClassVar[int] = 16
     _player_execution_cache: ClassVar[dict[Any, Any]] = {}
 
     def encode(
         self,
         rich_chk_section: RichTrigSection,
         context: RichChkEncodeContext,
-    ) -> bytes:
+    ) -> Union[bytes, bytearray, TrigLazySpec]:
         if context.optimize:
             return self._fused_encode_to_bytes(rich_chk_section, context)
         return self._simple_encode_to_bytes(rich_chk_section, context)
@@ -111,7 +107,8 @@ class BatchedTrigEncodeOptimizer:
         trig_id = id(triggers)
         template_info = self._template_cache.get(trig_id)
         if template_info is None:
-            return None
+            template_info = self._build_template_info(triggers)
+            self._template_cache[trig_id] = template_info
         if template_info is False:
             return None
         nz_pairs, _, cond_patches, act_patches = template_info
@@ -321,7 +318,7 @@ class BatchedTrigEncodeOptimizer:
         self,
         rich_chk_section: RichTrigSection,
         context: RichChkEncodeContext,
-    ) -> bytes:
+    ) -> Union[bytes, bytearray, TrigLazySpec]:
         triggers = rich_chk_section.triggers
         trig_sz = self._NUM_BYTES_PER_TRIGGER
 
@@ -334,9 +331,9 @@ class BatchedTrigEncodeOptimizer:
             if template_info is not False:
                 nz_pairs, template_bytes, cond_patches, act_patches = template_info
                 n = len(triggers)
-                # Single-cond-patch fast path: compute amounts before allocation to
-                # enable cache hit that skips the 12 MB bytearray + strided writes.
-                if len(cond_patches) == 1 and not act_patches:
+                # Fast path for 1-cond-patch (with optional 1-act-patch): compute
+                # amounts before allocation to enable bytes cache hit.
+                if len(cond_patches) == 1:
                     cond_idx, cond_off_rel = cond_patches[0]
                     if (
                         cond_idx == 0
@@ -353,31 +350,58 @@ class BatchedTrigEncodeOptimizer:
                         ab = amt.tobytes()
                         ab_hash = hash(ab)
                     nz_pairs_id = id(nz_pairs)
-                    bytes_key = (nz_pairs_id, n, ab_hash)
-                    cached_b = self._fused_bytes_cache.get(bytes_key)
-                    if cached_b is not None:
-                        return cast(bytes, cached_b)
-                    nz_key = (nz_pairs_id, n)
-                    nz_bufs = self._nz_bufs_cache.get(nz_key)
-                    if nz_bufs is None:
-                        nz_bufs = [(pos, bytes([val]) * n) for pos, val in nz_pairs]
-                        self._nz_bufs_cache[nz_key] = nz_bufs
-                    if nz_pairs and len(nz_pairs) <= 64:
-                        data = bytearray(n * trig_sz)
-                        for pos, buf in nz_bufs:
-                            data[pos::trig_sz] = buf
+                    act_ab: Optional[bytes] = None
+                    act_off_rel: int = 0
+                    if not act_patches:
+                        bytes_key: Any = (nz_pairs_id, n, ab_hash)
+                    elif len(act_patches) == 1 and act_patches[0][0] == 0:
+                        _, act_off_rel = act_patches[0]
+                        if rich_chk_section.act0_amounts_bytes is not None:
+                            act_ab = rich_chk_section.act0_amounts_bytes
+                            act_ah = rich_chk_section.act0_amounts_hash
+                        else:
+                            _amt2 = array.array(
+                                "I",
+                                [
+                                    cast(SetDeathsAction, t._actions[0])._amount
+                                    for t in triggers
+                                ],
+                            )
+                            if _IS_BIG_ENDIAN:
+                                _amt2.byteswap()
+                            act_ab = _amt2.tobytes()
+                            act_ah = hash(act_ab)
+                        bytes_key = (nz_pairs_id, n, hash((ab_hash, act_ah)))
                     else:
-                        data = bytearray(template_bytes * n)
-                    data[cond_off_rel::trig_sz] = ab[0::4]
-                    data[cond_off_rel + 1 :: trig_sz] = ab[1::4]
-                    data[cond_off_rel + 2 :: trig_sz] = ab[2::4]
-                    data[cond_off_rel + 3 :: trig_sz] = ab[3::4]
-                    fc = self._fused_bytes_cache
-                    if len(fc) < self._FUSED_BYTES_CACHE_MAX:
-                        result_b = bytes(data)
-                        fc[bytes_key] = result_b
-                        return result_b
-                    return data
+                        bytes_key = None
+                    if bytes_key is not None:
+                        nz_key = (nz_pairs_id, n)
+                        nz_bufs = self._nz_bufs_cache.get(nz_key)
+                        if nz_bufs is None:
+                            nz_bufs = [(pos, bytes([val]) * n) for pos, val in nz_pairs]
+                            self._nz_bufs_cache[nz_key] = nz_bufs
+                        if len(nz_pairs) <= 64:
+                            return TrigLazySpec(
+                                n,
+                                trig_sz,
+                                nz_bufs,
+                                cond_off_rel,
+                                ab,
+                                act_off_rel,
+                                act_ab,
+                            )
+                        else:
+                            data = bytearray(template_bytes * n)
+                            data[cond_off_rel::trig_sz] = ab[0::4]
+                            data[cond_off_rel + 1 :: trig_sz] = ab[1::4]
+                            data[cond_off_rel + 2 :: trig_sz] = ab[2::4]
+                            data[cond_off_rel + 3 :: trig_sz] = ab[3::4]
+                            if act_ab is not None:
+                                data[act_off_rel::trig_sz] = act_ab[0::4]
+                                data[act_off_rel + 1 :: trig_sz] = act_ab[1::4]
+                                data[act_off_rel + 2 :: trig_sz] = act_ab[2::4]
+                                data[act_off_rel + 3 :: trig_sz] = act_ab[3::4]
+                            return data
                 # Zero-fill + strided writes: faster than template * n for sparse templates
                 # because bytearray(N) uses calloc (near-zero cost for reused pages) while
                 # template * n does a full 12 MB copy of mostly-zero content.

--- a/src/richchk/transcoder/richchk/transcoders/trig/conditions/rich_trigger_deaths_condition_transcoder.py
+++ b/src/richchk/transcoder/richchk/transcoders/trig/conditions/rich_trigger_deaths_condition_transcoder.py
@@ -21,6 +21,8 @@ class RichTriggerDeathsConditionTranscoder(
     _RichTriggerConditionRegistrableTranscoder,
     trigger_condition_id=DeathsCondition.condition_id(),
 ):
+    _CONDITION_ID_INT: int = DeathsCondition.condition_id().id
+
     def __init__(self) -> None:
         self.log = logger.get_logger(RichTriggerDeathsConditionTranscoder.__name__)
 
@@ -46,13 +48,11 @@ class RichTriggerDeathsConditionTranscoder(
     ) -> DecodedTriggerCondition:
         return DecodedTriggerCondition(
             _location_id=0,
-            _group=RichChkEnumTranscoder.encode_enum(rich_condition.group),
-            _quantity=rich_condition.amount,
-            _unit_id=RichChkEnumTranscoder.encode_enum(rich_condition.unit),
-            _numeric_comparison_operation=RichChkEnumTranscoder.encode_enum(
-                rich_condition.comparator
-            ),
-            _condition_id=rich_condition.condition_id().id,
+            _group=rich_condition._group._id,
+            _quantity=rich_condition._amount,
+            _unit_id=rich_condition._unit._id,
+            _numeric_comparison_operation=rich_condition._comparator._id,
+            _condition_id=self._CONDITION_ID_INT,
             _numeric_comparand_type=0,
             _flags=0,
             _mask_flag=0,

--- a/src/richchk/transcoder/richchk/transcoders/trig/rich_trigger_action_transcoder.py
+++ b/src/richchk/transcoder/richchk/transcoders/trig/rich_trigger_action_transcoder.py
@@ -1,17 +1,20 @@
 """Represents an abstract class for decoding trigger actions into rich trigger
 actions."""
 
+import dataclasses
 from abc import abstractmethod
 from typing import Any, Protocol, TypeVar, runtime_checkable
 
 from .....model.chk.trig.decoded_trigger_action import DecodedTriggerAction
 from .....model.richchk.richchk_decode_context import RichChkDecodeContext
 from .....model.richchk.richchk_encode_context import RichChkEncodeContext
+from .....model.richchk.trig.actions.flags.trigger_action_flags import (
+    _DEFAULT_TRIGGER_ACTION_FLAGS,
+)
 from .....model.richchk.trig.rich_trigger_action import RichTriggerAction
 from .....transcoder.richchk.transcoders.helpers.trigger_action_flags_transcoder import (
     TriggerActionFlagsTranscoder,
 )
-from .....util.dataclasses_util import build_dataclass_with_fields
 
 _T = TypeVar("_T", bound=RichTriggerAction, contravariant=True)
 _U = TypeVar("_U", bound=DecodedTriggerAction, contravariant=False, covariant=False)
@@ -25,13 +28,14 @@ class RichTriggerActionTranscoder(Protocol[_T, _U]):
     def decode(
         self, decoded_action: _U, rich_chk_decode_context: RichChkDecodeContext
     ) -> RichTriggerAction:
-        return build_dataclass_with_fields(
-            self._decode(
-                decoded_action,
-                rich_chk_decode_context,
-            ),
-            _flags=TriggerActionFlagsTranscoder.decode_flags(decoded_action.flags),
-        )
+        flags_int = decoded_action.flags
+        rich = self._decode(decoded_action, rich_chk_decode_context)
+        if flags_int == 0:
+            return rich
+        return dataclasses.replace(
+            rich,
+            _flags=TriggerActionFlagsTranscoder.decode_flags(flags_int),
+        )  # type: ignore[call-arg]
 
     @abstractmethod
     def _decode(
@@ -42,13 +46,15 @@ class RichTriggerActionTranscoder(Protocol[_T, _U]):
     def encode(
         self, rich_action: _T, rich_chk_encode_context: RichChkEncodeContext
     ) -> _U:
-        return build_dataclass_with_fields(
-            self._encode(
-                rich_action,
-                rich_chk_encode_context,
-            ),
-            _flags=TriggerActionFlagsTranscoder.encode_flags(rich_action.flags),
-        )
+        decoded = self._encode(rich_action, rich_chk_encode_context)
+        # Identity check: almost all actions use the shared default flags singleton.
+        # This avoids calling encode_flags() (5 bool→int conversions) in the common case.
+        if rich_action.flags is _DEFAULT_TRIGGER_ACTION_FLAGS:
+            return decoded
+        flags_int = TriggerActionFlagsTranscoder.encode_flags(rich_action.flags)
+        if flags_int == 0:
+            return decoded
+        return dataclasses.replace(decoded, _flags=flags_int)
 
     @abstractmethod
     def _encode(

--- a/src/richchk/transcoder/richchk/transcoders/trig/rich_trigger_action_transcoder_factory.py
+++ b/src/richchk/transcoder/richchk/transcoders/trig/rich_trigger_action_transcoder_factory.py
@@ -24,12 +24,18 @@ class RichTriggerActionTranscoderFactory:
             ],
         ]
     ] = {}
+    _instances: ClassVar[
+        dict[TriggerActionId, RichTriggerActionTranscoder[Any, Any]]
+    ] = {}
 
     @classmethod
     def make_rich_trigger_action_transcoder(
         cls, trig_action_id: TriggerActionId
     ) -> RichTriggerActionTranscoder[Any, Any]:
         """Factory for making RichTrigActionTranscoder for a given trigger action ID."""
+        cached = cls._instances.get(trig_action_id)
+        if cached is not None:
+            return cached
         try:
             maybe_transcoder: Union[
                 RichTriggerActionTranscoder[Any, Any],
@@ -37,6 +43,7 @@ class RichTriggerActionTranscoderFactory:
             ] = cls.transcoders[trig_action_id]()
             assert isinstance(maybe_transcoder, RichTriggerActionTranscoder)
             retval: RichTriggerActionTranscoder[Any, Any] = maybe_transcoder
+            cls._instances[trig_action_id] = retval
             return retval
         except KeyError as err:
             raise NotImplementedError(f"{trig_action_id=} doesn't exist") from err

--- a/src/richchk/transcoder/richchk/transcoders/trig/rich_trigger_condition_transcoder.py
+++ b/src/richchk/transcoder/richchk/transcoders/trig/rich_trigger_condition_transcoder.py
@@ -1,17 +1,20 @@
 """Represents an abstract class for decoding trigger actions into rich trigger
 actions."""
 
+import dataclasses
 from abc import abstractmethod
 from typing import Any, Protocol, TypeVar, runtime_checkable
 
 from .....model.chk.trig.decoded_trigger_condition import DecodedTriggerCondition
 from .....model.richchk.richchk_decode_context import RichChkDecodeContext
 from .....model.richchk.richchk_encode_context import RichChkEncodeContext
+from .....model.richchk.trig.conditions.flags.trigger_condition_flags import (
+    _DEFAULT_TRIGGER_CONDITION_FLAGS,
+)
 from .....model.richchk.trig.rich_trigger_condition import RichTriggerCondition
 from .....transcoder.richchk.transcoders.helpers.trigger_condition_flags_transcoder import (
     TriggerConditionFlagsTranscoder,
 )
-from .....util.dataclasses_util import build_dataclass_with_fields
 
 _T = TypeVar(
     "_T",
@@ -29,15 +32,14 @@ class RichTriggerConditionTranscoder(Protocol[_T, _U]):
     def decode(
         self, decoded_condition: _U, rich_chk_decode_context: RichChkDecodeContext
     ) -> RichTriggerCondition:
-        return build_dataclass_with_fields(
-            self._decode(
-                decoded_condition,
-                rich_chk_decode_context,
-            ),
-            _flags=TriggerConditionFlagsTranscoder.decode_flags(
-                decoded_condition.flags
-            ),
-        )
+        flags_int = decoded_condition.flags
+        rich = self._decode(decoded_condition, rich_chk_decode_context)
+        if flags_int == 0:
+            return rich
+        return dataclasses.replace(
+            rich,
+            _flags=TriggerConditionFlagsTranscoder.decode_flags(flags_int),
+        )  # type: ignore[call-arg]
 
     @abstractmethod
     def _decode(
@@ -50,10 +52,14 @@ class RichTriggerConditionTranscoder(Protocol[_T, _U]):
     def encode(
         self, rich_condition: _T, rich_chk_encode_context: RichChkEncodeContext
     ) -> _U:
-        return build_dataclass_with_fields(
-            self._encode(rich_condition, rich_chk_encode_context),
-            _flags=TriggerConditionFlagsTranscoder.encode_flags(rich_condition.flags),
-        )
+        decoded = self._encode(rich_condition, rich_chk_encode_context)
+        # Identity check: almost all conditions use the shared default flags singleton.
+        if rich_condition.flags is _DEFAULT_TRIGGER_CONDITION_FLAGS:
+            return decoded
+        flags_int = TriggerConditionFlagsTranscoder.encode_flags(rich_condition.flags)
+        if flags_int == 0:
+            return decoded
+        return dataclasses.replace(decoded, _flags=flags_int)
 
     @abstractmethod
     def _encode(

--- a/src/richchk/transcoder/richchk/transcoders/trig/rich_trigger_condition_transcoder_factory.py
+++ b/src/richchk/transcoder/richchk/transcoders/trig/rich_trigger_condition_transcoder_factory.py
@@ -26,6 +26,9 @@ class RichTriggerConditionTranscoderFactory:
             ],
         ]
     ] = {}
+    _instances: ClassVar[
+        dict[TriggerConditionId, RichTriggerConditionTranscoder[Any, Any]]
+    ] = {}
 
     @classmethod
     def make_rich_trigger_condition_transcoder(
@@ -33,6 +36,9 @@ class RichTriggerConditionTranscoderFactory:
     ) -> RichTriggerConditionTranscoder[Any, Any]:
         """Factory for making RichTriggerConditionTranscoder for a given trigger
         condition ID."""
+        cached = cls._instances.get(condition_id)
+        if cached is not None:
+            return cached
         try:
             maybe_transcoder: Union[
                 RichTriggerConditionTranscoder[Any, Any],
@@ -40,6 +46,7 @@ class RichTriggerConditionTranscoderFactory:
             ] = cls.transcoders[condition_id]()
             assert isinstance(maybe_transcoder, RichTriggerConditionTranscoder)
             retval: RichTriggerConditionTranscoder[Any, Any] = maybe_transcoder
+            cls._instances[condition_id] = retval
             return retval
         except KeyError as err:
             raise NotImplementedError(f"{condition_id=} doesn't exist") from err

--- a/src/richchk/util/dataclasses_util.py
+++ b/src/richchk/util/dataclasses_util.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, Tuple, Type, TypeVar
 
 if TYPE_CHECKING:
     from _typeshed import DataclassInstance
@@ -7,6 +7,8 @@ if TYPE_CHECKING:
     _T = TypeVar("_T", bound=DataclassInstance)
 else:
     _T = TypeVar("_T", bound=object)
+
+_fields_by_type: dict[Type[Any], Tuple[Any, ...]] = {}
 
 
 def build_dataclass_with_fields(from_obj: _T, **kwargs: Any) -> _T:
@@ -16,10 +18,17 @@ def build_dataclass_with_fields(from_obj: _T, **kwargs: Any) -> _T:
     :param kwargs:
     :return:
     """
+    obj_type = type(from_obj)
+    fields = _fields_by_type.get(obj_type)
+    if fields is None:
+        fields = dataclasses.fields(from_obj)
+        _fields_by_type[obj_type] = fields
     new_fields = {}
-    for field in dataclasses.fields(from_obj):
+    for field in fields:
+        if not field.init:
+            continue
         if field.name not in kwargs:
             new_fields[field.name] = getattr(from_obj, field.name)
         else:
             new_fields[field.name] = kwargs[field.name]
-    return type(from_obj)(**new_fields)
+    return obj_type(**new_fields)

--- a/src/richchk/util/logger.py
+++ b/src/richchk/util/logger.py
@@ -17,6 +17,9 @@ LOGDIR = os.path.join(SCRIPT_PATH, "logs")
 BASE_LOG = os.path.join(LOGDIR, "richchk.log")
 _DEFAULT_LOG_LEVEl = logging.INFO
 
+_logger_cache: dict[str, logging.Logger] = {}
+_log_level_cache: dict[str, int] = {}
+
 
 class Logger(object):
     def __init__(
@@ -67,12 +70,16 @@ def get_logger(
     _use_default_log_level: bool = False,
 ) -> logging.Logger:
     """Define absolute paths for logfile and logdir for outside usage!"""
-    return Logger(
-        name,
-        log_file=logfile,
-        log_dir=logdir,
-        _use_default_log_level=_use_default_log_level,
-    ).get()
+    env_val = os.getenv(RICHCHK_CONFIG_ENV_VAR, "")
+    cache_key = f"{name}:{_use_default_log_level}:{env_val}"
+    if cache_key not in _logger_cache:
+        _logger_cache[cache_key] = Logger(
+            name,
+            log_file=logfile,
+            log_dir=logdir,
+            _use_default_log_level=_use_default_log_level,
+        ).get()
+    return _logger_cache[cache_key]
 
 
 def _determine_log_level_or_default() -> int:
@@ -88,8 +95,11 @@ def _determine_log_level_or_default() -> int:
 
     :return:
     """
-    innerlog = get_logger("RichChkLoggingConfig", _use_default_log_level=True)
     maybe_config_file = os.getenv(RICHCHK_CONFIG_ENV_VAR)
+    cache_key = maybe_config_file or ""
+    if cache_key in _log_level_cache:
+        return _log_level_cache[cache_key]
+    innerlog = get_logger("RichChkLoggingConfig", _use_default_log_level=True)
     if maybe_config_file and os.path.exists(maybe_config_file):
         # Read config file
         with open(maybe_config_file, "r") as f:
@@ -101,6 +111,7 @@ def _determine_log_level_or_default() -> int:
         innerlog.debug(
             f"Using non-default log level {log_level} specified in {maybe_config_file}"
         )
+        _log_level_cache[cache_key] = logging_level
         return logging_level
     elif maybe_config_file and not os.path.exists(maybe_config_file):
         innerlog.error(
@@ -108,4 +119,5 @@ def _determine_log_level_or_default() -> int:
             f"by environment variable {RICHCHK_CONFIG_ENV_VAR} ; using default logging level.  "
             f"File {maybe_config_file} does not exist!"
         )
+    _log_level_cache[cache_key] = _DEFAULT_LOG_LEVEl
     return _DEFAULT_LOG_LEVEl

--- a/test/io/richchk/rich_chk_io_test.py
+++ b/test/io/richchk/rich_chk_io_test.py
@@ -19,6 +19,7 @@ from richchk.model.chk_section_name import ChkSectionName
 from richchk.model.richchk.rich_chk import RichChk
 from richchk.model.richchk.rich_chk_section import RichChkSection
 from richchk.model.richchk.unis.rich_unis_section import RichUnisSection
+from richchk.transcoder.chk.transcoders.chk_trig_transcoder import ChkTrigTranscoder
 from richchk.transcoder.richchk.richchk_section_transcoder_factory import (
     RichChkSectionTranscoderFactory,
 )
@@ -142,9 +143,21 @@ def assert_chks_are_equal(decoded_chk1: DecodedChk, decoded_chk2: DecodedChk):
     )
     for index, section in enumerate(decoded_chk1.decoded_chk_sections):
         if isinstance(section, DecodedTrigSection):
+            other = decoded_chk2.decoded_chk_sections[index]
+            trig_tc = ChkTrigTranscoder()
+            s = (
+                trig_tc.decode(section._raw_data)
+                if section._raw_data is not None
+                else section
+            )
+            o = (
+                trig_tc.decode(other._raw_data)
+                if other._raw_data is not None
+                else other
+            )
             unittest.TestCase().assertEqual(
-                section,
-                decoded_chk2.decoded_chk_sections[index],
+                s,
+                o,
                 "Actual trig section does not match expected trig section!",
             )
         else:

--- a/test/transcoder/richchk/transcoders/richchk_trig_transcoder_test.py
+++ b/test/transcoder/richchk/transcoders/richchk_trig_transcoder_test.py
@@ -146,8 +146,10 @@ def test_integration_it_decodes_and_encodes_back_to_chk_without_changing_data(
         rich_chk_decode_context=real_rich_chk_decode_context,
     )
     decoded_trig_again = rich_transcoder.encode(rich_trig, real_rich_chk_encode_context)
-    assert decoded_trig_again == real_decoded_trig
-    rich_trig_again = rich_transcoder.decode(
-        decoded_trig_again, real_rich_chk_decode_context
-    )
+    chk_transcoder = ChkTrigTranscoder()
+    encoded_bytes = chk_transcoder.encode(decoded_trig_again, include_header=False)
+    expected_bytes = chk_transcoder.encode(real_decoded_trig, include_header=False)
+    assert encoded_bytes == expected_bytes
+    re_decoded = chk_transcoder.decode(encoded_bytes)
+    rich_trig_again = rich_transcoder.decode(re_decoded, real_rich_chk_decode_context)
     assert rich_trig_again == rich_trig


### PR DESCRIPTION
The TRIG encode path (used by hyper-trigger map builds) was the dominant bottleneck. Each encode_chk call was re-allocating ~2400 byte buffers per trigger and re-walking the entire RichChk object graph multiple times to collect strings, locations, switches, and CUWP slots.

Key changes:
- Fused TRIG encoder with pre-built templates and strided zero-fill so repeated triggers only patch the differing fields rather than building from scratch.
- Single-pass object collector that walks the RichChk graph once to gather all strings/locations/switches/CUWPs, replacing four separate walks.
- Identity-based caching with weakref eviction on:
  - encode_chk result (richchk_io)
  - per-section bytes (chk_io)
  - SWNM/UPRP/UPUS/MRGN/STR rebuild results
  - UPRP and SWNM encode results