### PR TITLE
Add lose-vision AI scripts for all 8 players

### DIFF
--- a/src/richchk/model/richchk/trig/enums/ai_script.py
+++ b/src/richchk/model/richchk/trig/enums/ai_script.py
@@ -78,3 +78,35 @@ class KnownAiScript(Enum):
         "+Vi7",
         "Turn on shared vision of Player 8 with current player",
     )
+    TURN_OFF_SHARED_VISION_WITH_PLAYER_1 = AiScript(
+        "-Vi0",
+        "Turn off shared vision of Player 1 with current player",
+    )
+    TURN_OFF_SHARED_VISION_WITH_PLAYER_2 = AiScript(
+        "-Vi1",
+        "Turn off shared vision of Player 2 with current player",
+    )
+    TURN_OFF_SHARED_VISION_WITH_PLAYER_3 = AiScript(
+        "-Vi2",
+        "Turn off shared vision of Player 3 with current player",
+    )
+    TURN_OFF_SHARED_VISION_WITH_PLAYER_4 = AiScript(
+        "-Vi3",
+        "Turn off shared vision of Player 4 with current player",
+    )
+    TURN_OFF_SHARED_VISION_WITH_PLAYER_5 = AiScript(
+        "-Vi4",
+        "Turn off shared vision of Player 5 with current player",
+    )
+    TURN_OFF_SHARED_VISION_WITH_PLAYER_6 = AiScript(
+        "-Vi5",
+        "Turn off shared vision of Player 6 with current player",
+    )
+    TURN_OFF_SHARED_VISION_WITH_PLAYER_7 = AiScript(
+        "-Vi6",
+        "Turn off shared vision of Player 7 with current player",
+    )
+    TURN_OFF_SHARED_VISION_WITH_PLAYER_8 = AiScript(
+        "-Vi7",
+        "Turn off shared vision of Player 8 with current player",
+    )


### PR DESCRIPTION
The turn-on shared vision scripts (-Vi0 through -Vi7) were missing from KnownAiScript, making it impossible to revoke shared vision via a trigger action without constructing a raw AiScript manually.