### PR TITLE
Fix string offset calculation for multi-byte UTF-8 strings

### DIFF
--- a/src/richchk/editor/chk/decoded_str_section_editor.py
+++ b/src/richchk/editor/chk/decoded_str_section_editor.py
@@ -9,6 +9,7 @@ from collections import OrderedDict
 
 from ...io.richchk.rich_str_lookup_builder import RichStrLookupBuilder
 from ...model.chk.str.decoded_str_section import DecodedStrSection
+from ...transcoder.chk.strings_common import _STRING_ENCODING
 from ...transcoder.chk.transcoders.chk_str_transcoder import ChkStrTranscoder
 from ...util import logger
 
@@ -73,13 +74,17 @@ class DecodedStrSectionEditor:
                     highest_string,
                 ) = self._find_initial_highest_offset_and_string(decoded_str_section)
                 new_offset = (
-                    (highest_offset + total_offset_increase) + len(highest_string) + 1
+                    (highest_offset + total_offset_increase)
+                    + len(highest_string.encode(_STRING_ENCODING))
+                    + 1
                 )
             else:
                 # if they are defined, we use the previous string offset we just added
                 # new_offset = string_offsets[-1] + len(strings_[-1]) + 1
                 # +1 is there to skip the null terminator
-                new_offset = highest_offset + len(highest_string) + 1
+                new_offset = (
+                    highest_offset + len(highest_string.encode(_STRING_ENCODING)) + 1
+                )
             new_string_offsets.append(new_offset)
             # set up the next string being added, if any
             highest_offset = new_offset

--- a/src/richchk/editor/chk/decoded_strx_section_editor.py
+++ b/src/richchk/editor/chk/decoded_strx_section_editor.py
@@ -9,6 +9,7 @@ from collections import OrderedDict
 
 from ...io.richchk.rich_str_lookup_builder import RichStrLookupBuilder
 from ...model.chk.strx.decoded_strx_section import DecodedStrxSection
+from ...transcoder.chk.strings_common import _STRING_ENCODING
 from ...transcoder.chk.transcoders.chk_strx_transcoder import ChkStrxTranscoder
 from ...util import logger
 
@@ -76,13 +77,17 @@ class DecodedStrxSectionEditor:
                     highest_string,
                 ) = self._find_initial_highest_offset_and_string(decoded_strx_section)
                 new_offset = (
-                    (highest_offset + total_offset_increase) + len(highest_string) + 1
+                    (highest_offset + total_offset_increase)
+                    + len(highest_string.encode(_STRING_ENCODING))
+                    + 1
                 )
             else:
                 # if they are defined, we use the previous string offset we just added
                 # new_offset = string_offsets[-1] + len(strings_[-1]) + 1
                 # +1 is there to skip the null terminator
-                new_offset = highest_offset + len(highest_string) + 1
+                new_offset = (
+                    highest_offset + len(highest_string.encode(_STRING_ENCODING)) + 1
+                )
             new_string_offsets.append(new_offset)
             # set up the next string being added, if any
             highest_offset = new_offset


### PR DESCRIPTION
## Summary
- Use `len(string.encode(_STRING_ENCODING))` instead of `len(string)` when calculating byte offsets in STR/STRX section editors
- Fixes offset corruption when strings contain multi-byte UTF-8 characters (e.g. smart quotes), which caused cascading KeyErrors for all subsequent strings

## Why
Python's `len(string)` returns the character count, but CHK string offsets are byte positions. For ASCII-only strings these are identical, but multi-byte UTF-8 characters (like smart quotes) have `len()` < byte length. A single string with 391 characters but 393 UTF-8 bytes caused 80 downstream strings to become unreachable.

## Test plan
- [ ] Run `pytest test/` to verify round-trip encoding tests still pass
- [ ] Build a map with multi-byte UTF-8 strings and verify all strings are reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)